### PR TITLE
One extra check befor using a new cookie-object

### DIFF
--- a/lib/Catalyst/Engine.pm
+++ b/lib/Catalyst/Engine.pm
@@ -94,7 +94,7 @@ sub finalize_cookies {
             )
         );
 
-        push @cookies, $cookie->as_string;
+        push @cookies, $cookie->as_string if $cookie;
     }
 
     for my $cookie (@cookies) {


### PR DESCRIPTION
I got sometimes the following error, its not totally clear how to reproduce (hacker testing our service/faking cookies?), but the fix should handle it. CGI::Simple::Cookie can return undef, when name or value is not defined and then $cookie->as_string throws this error:

Caught exception in engine "Can't call method "as_string" on an undefined value at /home/websuche/perl5lib
/lib/site_perl/5.10.1/Catalyst/Engine.pm line 97.
