### PR TITLE
Fixed up uses of catdir being used to return a file path

### DIFF
--- a/lib/Catalyst/ScriptRunner.pm
+++ b/lib/Catalyst/ScriptRunner.pm
@@ -35,7 +35,7 @@ sub subclass_with_traits {
 sub run {
     my ($self, $appclass, $scriptclass) = @_;
 
-    if (grep { -f File::Spec->catdir($FindBin::Bin, '..', $_) } Catalyst::Utils::dist_indicator_file_list()) {
+    if (grep { -f File::Spec->catfile($FindBin::Bin, '..', $_) } Catalyst::Utils::dist_indicator_file_list()) {
         lib->import(File::Spec->catdir($FindBin::Bin, '..', 'lib'));
     }
 

--- a/t/aggregate/unit_utils_home.t
+++ b/t/aggregate/unit_utils_home.t
@@ -15,7 +15,7 @@ my $cwd = cwd();
 foreach my $inc ('', 'lib', 'blib'){
     my $d = tempdir(CLEANUP => 1);
     chdir($d);
-    local $INC{'MyApp.pm'} = File::Spec->catdir($d, $inc, 'MyApp.pm');
+    local $INC{'MyApp.pm'} = File::Spec->catfile($d, $inc, 'MyApp.pm');
     ok !Catalyst::Utils::home('MyApp'), "No files found inc $inc";
     open(my $fh, '>', "Makefile.PL");
     close($fh);
@@ -24,7 +24,7 @@ foreach my $inc ('', 'lib', 'blib'){
 
 {
     my $d = tempdir(CLEANUP => 1);
-    local $INC{'MyApp.pm'} = File::Spec->catdir($d, 'MyApp.pm');
+    local $INC{'MyApp.pm'} = File::Spec->catfile($d, 'MyApp.pm');
     ok !Catalyst::Utils::home('MyApp'), 'No files found';
     mkdir File::Spec->catdir($d, 'MyApp');
     is Catalyst::Utils::home('MyApp'), dir($d, 'MyApp')->absolute->cleanup;

--- a/t/psgi_file_testapp.t
+++ b/t/psgi_file_testapp.t
@@ -14,7 +14,7 @@ BEGIN {
     $temp = tempdir( CLEANUP => 1 );
 
     $ENV{CATALYST_HOME} = $temp;
-    open(my $psgi, '>', File::Spec->catdir($temp, 'testapp.psgi')) or die;
+    open(my $psgi, '>', File::Spec->catfile($temp, 'testapp.psgi')) or die;
     print $psgi q{
         use strict;
         use TestApp;

--- a/t/psgi_file_testapp_engine_psgi_compat.t
+++ b/t/psgi_file_testapp_engine_psgi_compat.t
@@ -14,7 +14,7 @@ BEGIN {
     $temp = tempdir( CLEANUP => 1 );
 
     $ENV{CATALYST_HOME} = $temp;
-    open(my $psgi, '>', File::Spec->catdir($temp, 'testapp.psgi')) or die;
+    open(my $psgi, '>', File::Spec->catfile($temp, 'testapp.psgi')) or die;
     print $psgi q{
         use strict;
         use TestApp;


### PR DESCRIPTION
I'll send a ref to this to the cat-dev list, but pushing to github is easiest 
to me so flagging with a pull req seemed a reasonable next move :-)

catdir and catfile are different - using them interchangeably may
work on most platforms, but one day you will encounter VMS
and get horribly confused!
