### PR TITLE
Fixed wrong version number in POD

### DIFF
--- a/lib/Catalyst/Runtime.pm
+++ b/lib/Catalyst/Runtime.pm
@@ -19,7 +19,7 @@ See L<Catalyst>.
 
 =head1 DESCRIPTION
 
-This is the primary class for the Catalyst-Runtime distribution, version 5.80.
+This is the primary class for the Catalyst-Runtime distribution, version 5.90.
 
 =head1 AUTHORS & COPYRIGHT
 


### PR DESCRIPTION
`Catalyst::Runtime` still mentions `5.80` in the documentation. This patch fixes this.
