### PR TITLE
Minor doc fix, :Path example

### DIFF
--- a/lib/Catalyst/Controller.pm
+++ b/lib/Catalyst/Controller.pm
@@ -740,7 +740,7 @@ Handle various types of paths:
     ...
 
     sub myaction1 :Path { ... }  # -> /baz
-    sub myaction2 :Path('foo') { ... } # -> /baz/bar
+    sub myaction2 :Path('foo') { ... } # -> /baz/foo
     sub myaction2 :Path('/bar') { ... } # -> /bar
   }
 


### PR DESCRIPTION
The second example uses the token 'foo' with the token in the url being 'bar'. I elected to use 'foo' for both.
