### PR TITLE
Regression? sprintf used pointlessly for elapsed time math

### DIFF
--- a/lib/Catalyst.pm
+++ b/lib/Catalyst.pm
@@ -1828,7 +1828,7 @@ sub finalize {
     $c->log_response;
 
     if ($c->use_stats) {
-        my $elapsed = sprintf '%f', $c->stats->elapsed;
+        my $elapsed = $c->stats->elapsed;
         my $av = $elapsed == 0 ? '??' : sprintf '%.3f', 1 / $elapsed;
         $c->log->info(
             "Request took ${elapsed}s ($av/s)\n" . $c->stats->report . "\n" );


### PR DESCRIPTION
...ommits/07aamdmf1g/r6979-in-catalyst-runtime-5-70-trunk-lib

Without this change locale settings can give "isn't numeric in numeric eq (==) " warnings on every request when the 0.00 point decimal is replaced with a comma.
