### PR TITLE
silent warnings.

### DIFF
--- a/lib/Catalyst/Script/Server.pm
+++ b/lib/Catalyst/Script/Server.pm
@@ -77,7 +77,7 @@ sub BUILD {
         my ($success, $error) = try_load_class("MooseX::Daemonize::Core");
         warn("MooseX::Daemonize is needed for the --background option: $error\n"),
             exit 1 if not $success;
-        my ($success, $error) = try_load_class("POSIX");
+        ($success, $error) = try_load_class("POSIX");
         warn("$error\n"), exit 1 if not $success;
         MooseX::Daemonize::Core->meta->apply($self);
         POSIX::close($_) foreach (0..2);


### PR DESCRIPTION
% ./script/myapp_server.pl
"my" variable $success masks earlier declaration in same scope at snip/Catalyst/Script/Server.pm line 80.
"my" variable $error masks earlier declaration in same scope at snip/Catalyst/Script/Server.pm line 80.
