### PR TITLE
Moved order of plugin setup back to pre 5.90052 location

### DIFF
--- a/lib/Catalyst.pm
+++ b/lib/Catalyst.pm
@@ -1133,14 +1133,6 @@ sub setup {
     $class->setup_log( delete $flags->{log} );
     $class->setup_plugins( delete $flags->{plugins} );
 
-    # Call plugins setup, this is stupid and evil.
-    # Also screws C3 badly on 5.10, hack to avoid.
-    {
-        no warnings qw/redefine/;
-        local *setup = sub { };
-        $class->setup unless $Catalyst::__AM_RESTARTING;
-    }
-
     $class->setup_middleware();
     $class->setup_data_handlers();
     $class->setup_dispatcher( delete $flags->{dispatcher} );
@@ -1172,6 +1164,14 @@ You are running an old script!
     catalyst.pl -scripts $class
 
 EOF
+    }
+
+    # Call plugins setup, this is stupid and evil.
+    # Also screws C3 badly on 5.10, hack to avoid.
+    {
+        no warnings qw/redefine/;
+        local *setup = sub { };
+        $class->setup unless $Catalyst::__AM_RESTARTING;
     }
 
     # Initialize our data structure


### PR DESCRIPTION
In 17176f15aa (v5.90052) the plugin setup block was moved up to be
called immediately after setup_plugins(), however, this causes issues
with initialization order of other plugins that hook into setup(). This
commit moves the block back down to just before setup_components, where
it used to be.
