### PR TITLE
Changed order of plugin setup block and setup_middleware

### DIFF
--- a/lib/Catalyst.pm
+++ b/lib/Catalyst.pm
@@ -1133,7 +1133,6 @@ sub setup {
     $class->setup_log( delete $flags->{log} );
     $class->setup_plugins( delete $flags->{plugins} );
 
-    $class->setup_middleware();
     $class->setup_data_handlers();
     $class->setup_dispatcher( delete $flags->{dispatcher} );
     if (my $engine = delete $flags->{engine}) {
@@ -1173,6 +1172,8 @@ EOF
         local *setup = sub { };
         $class->setup unless $Catalyst::__AM_RESTARTING;
     }
+
+    $class->setup_middleware();
 
     # Initialize our data structure
     $class->components( {} );


### PR DESCRIPTION
In 17176f15aa (v5.90052) the plugin setup block was moved up to be called immediately after setup_plugins(), however, this causes issues with initialization order of other plugins that hook into setup(). This commit moves the block back down to where it used to be. This also required setup_middleware to be moved down as well, immediately after the plugin setup block and before setup_components.
