### PR TITLE
Redirection security

### DIFF
--- a/lib/Catalyst/Response.pm
+++ b/lib/Catalyst/Response.pm
@@ -282,8 +282,8 @@ sub redirect {
         my $location = shift;
         my $status = shift || 302;
 
+        $self->location($location);
         $self->status($status);
-        $self->location($location);    # overwrites status if invalid
 
     }
 
@@ -300,9 +300,7 @@ around '_set_location' => sub {
 
         if ( $location =~ m/[\n\r]/ ) {    # check for header injection
 
-            $self->status(400);            # bad request
-
-            # TODO: warn about this or fail
+            die "blocking header injection";
 
         } else {
 


### PR DESCRIPTION
superseded by https://github.com/perl-catalyst/catalyst-runtime/compare/redirection-security-retry?expand=1

after discussion the cabal feels this is the wrong layer to handle this problem.  the PSGI spec itself rejects the kind of header with control chars, that this code is handling, so its probably better at the server layer, or possible some lint like middleware.  (or even enforced by whatever is creating the response).

do not merge
