### PR TITLE
Adds support to Script/Server.pm for env variable to set host

### DIFF
--- a/t/aggregate/unit_core_script_server.t
+++ b/t/aggregate/unit_core_script_server.t
@@ -27,6 +27,14 @@ testOption( [ qw// ], ['3000', undef, opthash()] );
 # host           -host --host              --host
 testOption( [ qw/--host testhost/ ], ['3000', 'testhost', opthash(host => 'testhost')] );
 testOption( [ qw/-h testhost/ ], ['3000', 'testhost', opthash(host => 'testhost')] );
+{
+    local $ENV{TESTAPPTOTESTSCRIPTS_HOST} = 'testhost';
+    testOption( [ qw// ], [3000, 'testhost', opthash(host => 'testhost')] );
+}
+{
+    local $ENV{CATALYST_HOST} = 'testhost';
+    testOption( [ qw// ], [3000, 'testhost', opthash(host => 'testhost')] );
+}
 
 # port           -p -port --port           -l --listen
 testOption( [ qw/-p 3001/ ], ['3001', undef, opthash(port => 3001)] );


### PR DESCRIPTION
This change allows a MYAPP_HOST or CATALYST_HOST environment variable to set the -h value for Server::Script, allowing it to be set as the port can be.

The only quirk is that the default value 'undef' isn't a valid Str type for Moose, and changing to Maybe[Str] confused MooseX::Getopt.  A type definition of MaybeStr that maps to =s in MooseX::Getopt sorts that out.  The other viable option would be to make the default an empty string instead of undef, but that seemed like more changes.  The code never uses it as anything but a truth check, so it would work.

If that's preferable, I can rework it to that pretty easily.  The tests will change more than the code.