### PR TITLE
Add a new name to the list in stopwords, to fix t/author/spelling.t

### DIFF
--- a/t/author/spelling.t
+++ b/t/author/spelling.t
@@ -77,6 +77,7 @@ add_stopwords(qw(
     Sedlacek
     Sheidlower
     SpiceMan
+    Styn
     Szilakszi
     Tatsuhiko
     Ulf
@@ -122,6 +123,7 @@ add_stopwords(qw(
     rainboxx
     sri
     szbalint
+    vanstyn
     willert
     wreis
 ));


### PR DESCRIPTION
Here's the spelling change, to ancona, as requested.
