### PR TITLE
Add 'lazy' to two parameters to let the constructor runs first

### DIFF
--- a/lib/Catalyst/Script/Server.pm
+++ b/lib/Catalyst/Script/Server.pm
@@ -37,6 +37,7 @@ has port => (
     cmd_aliases   => 'p',
     isa           => 'Int',
     is            => 'ro',
+    lazy          => 1,
     default       => sub {
         Catalyst::Utils::env_value(shift->application_name, 'port') || 3000
     },
@@ -107,6 +108,7 @@ has restart => (
     cmd_aliases   => 'r',
     isa           => 'Bool',
     is            => 'ro',
+    lazy          => 1,
     default       => sub {
         Catalyst::Utils::env_value(shift->application_name, 'reload') || 0;
     },

--- a/t/aggregate/unit_core_script_server.t
+++ b/t/aggregate/unit_core_script_server.t
@@ -151,7 +151,7 @@ sub testBackgroundOptionWithFork {
 
     ## Check a few args
     is_deeply $app->{ARGV}, $argstring;
-    is $app->{port}, '3000';
+    is $app->port, '3000';
     is($app->{background}, 1);
 }
 


### PR DESCRIPTION
and set the application name properly before they are used.  Without this,
the command line options are sometimes ignored.

One test had to change, as it assumed the port number would have been set,
when the method was never called.  Calling the method to get the port number
fixes this, by allowing the lazy method to actually be run before the value
is used.

Here's the pull request, to the ancona branch, as requested.
