### PR TITLE
Bugfix in Request.pm

### DIFF
--- a/lib/Catalyst/Request.pm
+++ b/lib/Catalyst/Request.pm
@@ -672,7 +672,7 @@ sub param {
     }
     elsif ( @params > 1 ) {
         my $field = shift @params;
-        $self->parameters->{$field} = [@_];
+        $self->parameters->{$field} = [@params];
     }
 }
 


### PR DESCRIPTION
Bugfix for setting with param() method. The name of the param was still in @_ and being included in the values to set. e.g.

param('foo','bar) should set parameters = { foo => bar } but gives {foo => [ foo, bar ]}
