### PR TITLE
Added minimum requested version of Carp to Makefile.pl

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -35,7 +35,7 @@ requires 'Data::OptList';
 requires 'Moose' => '1.03';
 requires 'MooseX::MethodAttributes::Role::AttrContainer::Inheritable' => '0.24';
 requires 'MooseX::Role::WithOverloading' => '0.09';
-requires 'Carp';
+requires 'Carp' => '1.25';
 requires 'Class::C3::Adopt::NEXT' => '0.07';
 requires 'CGI::Simple::Cookie' => '1.109';
 requires 'Data::Dump';


### PR DESCRIPTION
Carp >= 1.25 is required, because t/undef-params.t failing with older versions

t/undef-params.t ...................................................... 1/? 
# Failed test at t/undef-params.t line 36.
# got: 'You called ->params with an undefined value at t/undef-params.t line 20
# '
# expected: 'You called ->params with an undefined value at t/undef-params.t line 20.
# '
# Looks like you failed 1 test of 5.
