### PR TITLE
Fix OPTIONS HTTP Method

### DIFF
--- a/lib/Catalyst.pm
+++ b/lib/Catalyst.pm
@@ -4316,7 +4316,7 @@ acme: Leon Brocard <leon@astray.com>
 
 abraxxa: Alexander Hartmaier <abraxxa@cpan.org>
 
-André Walker <andre@cpan.org>
+andrewalker: André Walker <andre@cpan.org>
 
 Andrew Bramble
 

--- a/lib/Catalyst.pm
+++ b/lib/Catalyst.pm
@@ -4316,6 +4316,8 @@ acme: Leon Brocard <leon@astray.com>
 
 abraxxa: Alexander Hartmaier <abraxxa@cpan.org>
 
+André Walker <andre@cpan.org>
+
 Andrew Bramble
 
 Andrew Ford E<lt>A.Ford@ford-mason.co.ukE<gt>

--- a/lib/Catalyst/ActionRole/HTTPMethods.pm
+++ b/lib/Catalyst/ActionRole/HTTPMethods.pm
@@ -47,13 +47,13 @@ Catalyst::ActionRole::HTTPMethods - Match on HTTP Methods
 
     sub user_base : Chained('/') CaptureArg(0) { ... }
 
-      sub get_user    : Chained('user_base') Args(1) GET { ... }
-      sub post_user   : Chained('user_base') Args(1) POST { ... }
-      sub put_user    : Chained('user_base') Args(1) PUT { ... }
-      sub delete_user : Chained('user_base') Args(1) DELETE { ... }
-      sub head_user   : Chained('user_base') Args(1) HEAD { ... }
-      sub option_user : Chained('user_base') Args(1) OPTION { ... }
-      sub option_user : Chained('user_base') Args(1) PATCH { ... }
+      sub get_user     : Chained('user_base') Args(1) GET { ... }
+      sub post_user    : Chained('user_base') Args(1) POST { ... }
+      sub put_user     : Chained('user_base') Args(1) PUT { ... }
+      sub delete_user  : Chained('user_base') Args(1) DELETE { ... }
+      sub head_user    : Chained('user_base') Args(1) HEAD { ... }
+      sub options_user : Chained('user_base') Args(1) OPTIONS { ... }
+      sub patch_user   : Chained('user_base') Args(1) PATCH { ... }
 
 
       sub post_and_put : Chained('user_base') POST PUT Args(1) { ... }

--- a/lib/Catalyst/Controller.pm
+++ b/lib/Catalyst/Controller.pm
@@ -544,12 +544,12 @@ sub _parse_Does_attr {
     return Does => $self->_expand_role_shortname($value);
 }
 
-sub _parse_GET_attr    { Method => 'GET'    }
-sub _parse_POST_attr   { Method => 'POST'   }
-sub _parse_PUT_attr    { Method => 'PUT'    }
-sub _parse_DELETE_attr { Method => 'DELETE' }
-sub _parse_OPTION_attr { Method => 'OPTION' }
-sub _parse_HEAD_attr   { Method => 'HEAD'   }
+sub _parse_GET_attr     { Method => 'GET'     }
+sub _parse_POST_attr    { Method => 'POST'    }
+sub _parse_PUT_attr     { Method => 'PUT'     }
+sub _parse_DELETE_attr  { Method => 'DELETE'  }
+sub _parse_OPTIONS_attr { Method => 'OPTIONS' }
+sub _parse_HEAD_attr    { Method => 'HEAD'    }
 
 sub _expand_role_shortname {
     my ($self, @shortnames) = @_;

--- a/t/aggregate/live_component_controller_httpmethods.t
+++ b/t/aggregate/live_component_controller_httpmethods.t
@@ -1,13 +1,17 @@
 use strict;
 use warnings;
 use Test::More;
-use HTTP::Request::Common qw/GET POST DELETE PUT /;
+use HTTP::Request::Common qw/GET POST DELETE PUT/;
  
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 
 use Catalyst::Test 'TestApp';
- 
+
+sub OPTIONS {
+    HTTP::Request->new('OPTIONS', @_);
+}
+
 is(request(GET    '/httpmethods/foo')->content, 'get');
 is(request(POST   '/httpmethods/foo')->content, 'post');
 is(request(DELETE '/httpmethods/foo')->content, 'default');
@@ -33,5 +37,13 @@ is(request(DELETE '/httpmethods/get_put_post_delete')->content, 'delete2');
 is(request(GET    '/httpmethods/check_default')->content, 'get3');
 is(request(POST   '/httpmethods/check_default')->content, 'post3');
 is(request(PUT    '/httpmethods/check_default')->content, 'chain_default');
+
+is(request(GET    '/httpmethods/opt_typo')->content, 'typo');
+is(request(POST   '/httpmethods/opt_typo')->content, 'typo');
+is(request(PUT    '/httpmethods/opt_typo')->content, 'typo');
+
+is(request(OPTIONS '/httpmethods/opt')->content, 'options');
+is(request(GET     '/httpmethods/opt')->content, 'default');
+is(request(POST    '/httpmethods/opt')->content, 'default');
 
 done_testing;

--- a/t/author/spelling.t
+++ b/t/author/spelling.t
@@ -24,6 +24,7 @@ add_stopwords(qw(
     chunked chunking codewise distingush equivilent plack Javascript gzipping
     ConfigLoader getline whitepaper matchable
     Andreas
+    André
     Ashton
     Axel
     Balint

--- a/t/lib/TestApp/Controller/HTTPMethods.pm
+++ b/t/lib/TestApp/Controller/HTTPMethods.pm
@@ -30,6 +30,16 @@ sub any_method : Path('baz') {
     $ctx->response->body('any');
 }
 
+sub typo_option : Path('opt_typo') OPTION {
+    my ($self, $ctx) = @_;
+    $ctx->response->body('typo');
+}
+
+sub real_options : Path('opt') OPTIONS {
+    my ($self, $ctx) = @_;
+    $ctx->response->body('options');
+}
+
 sub base :Chained('/') PathPrefix CaptureArgs(0) { }
 
 sub chained_get :Chained('base') Args(0) GET {


### PR DESCRIPTION
The attribute that matched the OPTIONS HTTP method was spelled "OPTION"
instead of "OPTIONS". There's no such HTTP verb "OPTION".

This patch fixes documentation and implementation, and adds my name as a
contributor :)