### PR TITLE
Ordered actions matching

### DIFF
--- a/lib/Catalyst/Action.pm
+++ b/lib/Catalyst/Action.pm
@@ -152,8 +152,8 @@ sub compare {
     my @a2keys = $a2->compare_keys;
 
     for my $attr (uniq(@a1keys, @a2keys)) {
-        $cmp{a1}{$attr} = $a1->_compare_value($attr);
-        $cmp{a2}{$attr} = $a2->_compare_value($attr);
+        $cmp{a1}{$attr} = $a1->_compare_value($attr) * @a1keys;
+        $cmp{a2}{$attr} = $a2->_compare_value($attr) * @a2keys;
     }
 
     my $cmp = 0;

--- a/lib/Catalyst/Action.pm
+++ b/lib/Catalyst/Action.pm
@@ -81,13 +81,29 @@ sub match_captures { 1 }
 sub compare {
     my ($a1, $a2) = @_;
 
-    my ($a1_args) = @{ $a1->attributes->{Args} || [] };
-    my ($a2_args) = @{ $a2->attributes->{Args} || [] };
+    my %cmp = (
+        a1 => {},
+        a2 => {},
+    );
 
-    $_ = looks_like_number($_) ? $_ : ~0
-        for $a1_args, $a2_args;
+    ( $cmp{a1}{Args} ) = @{ $a1->attributes->{Args} || [] };
+    ( $cmp{a2}{Args} ) = @{ $a2->attributes->{Args} || [] };
 
-    return $a1_args <=> $a2_args;
+     $cmp{$_}{Args}
+        = looks_like_number( $cmp{$_}{Args} ) ? $cmp{$_}{Args} : ~0
+            for ('a1', 'a2');
+
+    for my $attr ('Method', 'Scheme', 'Consumes') {
+        $cmp{a1}{$attr} = @{ $a1->attributes->{$attr} || [] };
+        $cmp{a2}{$attr} = @{ $a2->attributes->{$attr} || [] };
+    }
+
+    return (
+           $cmp{a1}{Args}     <=> $cmp{a2}{Args}
+        || $cmp{a2}{Method}   <=> $cmp{a1}{Method}
+        || $cmp{a2}{Scheme}   <=> $cmp{a1}{Scheme}
+        || $cmp{a2}{Consumes} <=> $cmp{a1}{Consumes}
+    );
 }
 
 sub number_of_args {
@@ -164,8 +180,8 @@ makes the chain not match (and alternate, less preferred chains will be attempte
 
 =head2 compare
 
-Compares 2 actions based on the value of the C<Args> attribute, with no C<Args>
-having the highest precedence.
+Compares 2 actions based on the value of the C<Args>, C<Method>, C<Scheme> and C<Consumes> attributes.
+With no C<Args>, max C<Method>, C<Scheme> and C<Consumes> having the highest precedence.
 
 =head2 namespace
 

--- a/lib/Catalyst/ActionRole/ConsumesContent.pm
+++ b/lib/Catalyst/ActionRole/ConsumesContent.pm
@@ -4,19 +4,8 @@ use Moose::Role;
 
 requires 'match', 'match_captures', 'list_extra_info', 'compare_rules', 'compare_keys';
 
-around compare_rules => sub {
-    my $orig = shift;
-    my $self = shift;
-
-    return ( $self->$orig(@_), Consumes => -1 );
-};
-
-around compare_keys => sub {
-    my $orig = shift;
-    my $self = shift;
-
-    return ( $self->$orig(@_), 'Consumes' );
-};
+override compare_rules => sub { return ( super(), 'Consumes' => -1 ) };
+override compare_keys  => sub { return ( super(), 'Consumes' ) };
 
 has allowed_content_types => (
   is=>'ro',

--- a/lib/Catalyst/ActionRole/ConsumesContent.pm
+++ b/lib/Catalyst/ActionRole/ConsumesContent.pm
@@ -2,7 +2,21 @@ package Catalyst::ActionRole::ConsumesContent;
 
 use Moose::Role;
 
-requires 'match', 'match_captures', 'list_extra_info';
+requires 'match', 'match_captures', 'list_extra_info', 'compare_rules', 'compare_keys';
+
+around compare_rules => sub {
+    my $orig = shift;
+    my $self = shift;
+
+    return ( $self->$orig(@_), Consumes => -1 );
+};
+
+around compare_keys => sub {
+    my $orig = shift;
+    my $self = shift;
+
+    return ( $self->$orig(@_), 'Consumes' );
+};
 
 has allowed_content_types => (
   is=>'ro',

--- a/lib/Catalyst/ActionRole/HTTPMethods.pm
+++ b/lib/Catalyst/ActionRole/HTTPMethods.pm
@@ -2,7 +2,21 @@ package Catalyst::ActionRole::HTTPMethods;
 
 use Moose::Role;
 
-requires 'match', 'match_captures', 'list_extra_info';
+requires 'match', 'match_captures', 'list_extra_info', 'compare_rules', 'compare_keys';
+
+around compare_rules => sub {
+    my $orig = shift;
+    my $self = shift;
+
+    return ( $self->$orig(@_), Method => -1 );
+};
+
+around compare_keys => sub {
+    my $orig = shift;
+    my $self = shift;
+
+    return ( $self->$orig(@_), 'Method' );
+};
 
 around ['match','match_captures'] => sub {
   my ($orig, $self, $ctx, @args) = @_;

--- a/lib/Catalyst/ActionRole/HTTPMethods.pm
+++ b/lib/Catalyst/ActionRole/HTTPMethods.pm
@@ -4,19 +4,8 @@ use Moose::Role;
 
 requires 'match', 'match_captures', 'list_extra_info', 'compare_rules', 'compare_keys';
 
-around compare_rules => sub {
-    my $orig = shift;
-    my $self = shift;
-
-    return ( $self->$orig(@_), Method => -1 );
-};
-
-around compare_keys => sub {
-    my $orig = shift;
-    my $self = shift;
-
-    return ( $self->$orig(@_), 'Method' );
-};
+override compare_rules => sub { return ( super(), 'Method' => -1 ) };
+override compare_keys  => sub { return ( super(), 'Method' ) };
 
 around ['match','match_captures'] => sub {
   my ($orig, $self, $ctx, @args) = @_;

--- a/lib/Catalyst/ActionRole/Scheme.pm
+++ b/lib/Catalyst/ActionRole/Scheme.pm
@@ -4,19 +4,8 @@ use Moose::Role;
 
 requires 'match', 'match_captures', 'list_extra_info', 'compare_rules', 'compare_keys';
 
-around compare_rules => sub {
-    my $orig = shift;
-    my $self = shift;
-
-    return ( $self->$orig(@_), Scheme => -1 );
-};
-
-around compare_keys => sub {
-    my $orig = shift;
-    my $self = shift;
-
-    return ( $self->$orig(@_), 'Scheme' );
-};
+override compare_rules => sub { return ( super(), 'Scheme' => -1 ) };
+override compare_keys  => sub { return ( super(), 'Scheme' ) };
 
 around ['match','match_captures'] => sub {
     my ($orig, $self, $ctx, @args) = @_;

--- a/lib/Catalyst/ActionRole/Scheme.pm
+++ b/lib/Catalyst/ActionRole/Scheme.pm
@@ -2,7 +2,21 @@ package Catalyst::ActionRole::Scheme;
 
 use Moose::Role;
 
-requires 'match', 'match_captures', 'list_extra_info';
+requires 'match', 'match_captures', 'list_extra_info', 'compare_rules', 'compare_keys';
+
+around compare_rules => sub {
+    my $orig = shift;
+    my $self = shift;
+
+    return ( $self->$orig(@_), Scheme => -1 );
+};
+
+around compare_keys => sub {
+    my $orig = shift;
+    my $self = shift;
+
+    return ( $self->$orig(@_), 'Scheme' );
+};
 
 around ['match','match_captures'] => sub {
     my ($orig, $self, $ctx, @args) = @_;

--- a/lib/Catalyst/DispatchType/Chained.pm
+++ b/lib/Catalyst/DispatchType/Chained.pm
@@ -378,7 +378,10 @@ sub register {
 
     $action->attributes->{PathPart} = [ $encoded_part ];
 
-    unshift(@{ $children->{$encoded_part} ||= [] }, $action);
+    # "Reversed" sort: best actions should be at the end
+    $children->{$encoded_part} = [
+        sort { $b->compare($a) } ($action, @{ $children->{$encoded_part} || [] })
+    ];
 
     $self->_actions->{'/'.$action->reverse} = $action;
 

--- a/lib/Catalyst/DispatchType/Chained.pm
+++ b/lib/Catalyst/DispatchType/Chained.pm
@@ -220,6 +220,7 @@ sub recurse_match {
     my ( $self, $c, $parent, $path_parts ) = @_;
     my $children = $self->_children_of->{$parent};
     return () unless $children;
+
     my $best_action;
     my @captures;
     TRY: foreach my $try_part (sort { length($b) <=> length($a) }
@@ -380,7 +381,7 @@ sub register {
 
     # "Reversed" sort: best actions should be at the end
     $children->{$encoded_part} = [
-        sort { $b->compare($a) } ($action, @{ $children->{$encoded_part} || [] })
+        reverse sort { $a->compare($b) } ($action, @{ $children->{$encoded_part} || [] })
     ];
 
     $self->_actions->{'/'.$action->reverse} = $action;

--- a/t/lib/TestApp/Controller/HTTPMethods.pm
+++ b/t/lib/TestApp/Controller/HTTPMethods.pm
@@ -2,14 +2,10 @@ package TestApp::Controller::HTTPMethods;
 
 use Moose;
 use MooseX::MethodAttributes;
- 
+
 extends 'Catalyst::Controller';
- 
-sub default : Path Args {
-    my ($self, $ctx) = @_;
-    $ctx->response->body('default');
-}
- 
+
+
 sub get : Path('foo') Method('GET') {
     my ($self, $ctx) = @_;
     $ctx->response->body('get');
@@ -63,7 +59,7 @@ sub get_or_put :Chained('base') PathPart('get_put_post_delete') CaptureArgs(0) G
 sub get2 :Chained('get_or_put') PathPart('') Args(0) GET {
     pop->res->body('get2');
 }
-    
+
 sub put2 :Chained('get_or_put') PathPart('') Args(0) PUT {
     pop->res->body('put2');
 }
@@ -73,12 +69,16 @@ sub post_or_delete :Chained('base') PathPart('get_put_post_delete') CaptureArgs(
 sub post2 :Chained('post_or_delete') PathPart('') Args(0) POST {
     pop->res->body('post2');
 }
-    
+
 sub delete2 :Chained('post_or_delete') PathPart('') Args(0) DELETE {
     pop->res->body('delete2');
 }
 
 sub check_default :Chained('base') CaptureArgs(0) { }
+
+sub chain_default :Chained('check_default') PathPart('') Args(0) {
+    pop->res->body('chain_default');
+}
 
 sub default_get :Chained('check_default') PathPart('') Args(0) GET {
     pop->res->body('get3');
@@ -88,8 +88,9 @@ sub default_post :Chained('check_default') PathPart('') Args(0) POST {
     pop->res->body('post3');
 }
 
-sub chain_default :Chained('check_default') PathPart('') Args(0) {
-    pop->res->body('chain_default');
+sub default : Path Args {
+    my ($self, $ctx) = @_;
+    $ctx->response->body('default');
 }
 
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
Matching actions in Catalyst depends on action defining position.
It is OK until you use ActionRoles (eg HTTPMethods). Look:
```
    sub base: Chained('/') PathPart('options') CaptureArgs(0) {}
    sub load: Chained('base') CaptureArgs(1) {}
    sub show: GET OPTIONS Chained('load') Args(0) {}
    sub modify: Chained('load') Args(0) {}
```
POST /options/10 OK (modify)
PUT /options/10 OK (modify)
GET /options/10 OK (show)
OPTIONS /options/10 OK (show)
etc.

BUT! When you rearrange `show` and `modify`, then **ALL** calls will be handled by `modify` action:
```
    sub modify: Chained('load') Args(0) {...}
    sub show: GET OPTIONS Chained('load') Args(0) {...}
```
.
.
So, here is a patch to fix it for `Path` and `Chained`. Matching in `Chained` now depends on position via `Catalyst::Action/compare` (it considers Method, Scheme and Consumes action attributes).


PS: it has side effect: you can apply your own global ActionRole (eg Ordered) with own `compare` method and define matching order as you wish.

PPS: it is fine when you define all your actions in *each* controller. But when you have Base controller, and some controllers differs from Base only on attributes (Chained, PathPart etc, so you manage controller via config) and some controllers have different realization, it is becomes annoying to copy-paste the same code from one controller to another.
