### PR TITLE
Be careful of autovivification

### DIFF
--- a/lib/Catalyst/Action.pm
+++ b/lib/Catalyst/Action.pm
@@ -110,7 +110,7 @@ sub scheme {
 sub list_extra_info {
   my $self = shift;
   return {
-    Args => $self->attributes->{Args}[0],
+    Args => exists $self->attributes->{Args} ? $self->attributes->{Args}[0] : undef,
     CaptureArgs => $self->number_of_captures,
   }
 } 


### PR DESCRIPTION
Yes, `list_extra_info` is being used only in `DispatchType::Chained` and doesn't affect on other parts (until used).

But I'm cooking  Catalyst extension for ordered action matching (like [PR87](https://github.com/perl-catalyst/catalyst-runtime/pull/87)), and was surprised when on `CATALYST_DEBUG=1` tests were passed, but on `CATALYST_DEBUG=0` - not.