### PR TITLE
Catalyst::Controller "around action_namspace" contains Legacy Code which is faulty and MUST be removed

### DIFF
--- a/lib/Catalyst/Controller.pm
+++ b/lib/Catalyst/Controller.pm
@@ -204,7 +204,9 @@ around action_namespace => sub {
             $case_s = $class->config->{case_sensitive};
         } else {
             if (ref $self) {
-                $case_s = ref($self->_application)->config->{case_sensitive};
+                my $_app = $self->_application;
+                my $_app_class = ref($self->_application) || $self->_application;
+                $case_s = $_app_class->config->{case_sensitive};
             } else {
                 confess("Can't figure out case_sensitive setting");
             }


### PR DESCRIPTION
Changed the ticket to the real problem it revealed, there is an old legacy fallback in this modifier, that expect _application to be an instance instead only the application class name.