### PR TITLE
Die in engine if prepare_body writing to psgi.input fails.

### DIFF
--- a/lib/Catalyst/Request.pm
+++ b/lib/Catalyst/Request.pm
@@ -293,7 +293,10 @@ sub prepare_body {
     # Check for definedness as you could read '0'
     while ( defined ( my $chunk = $self->read() ) ) {
         $self->prepare_body_chunk($chunk);
-        $stream_buffer->print($chunk) if $stream_buffer;
+        next unless $stream_buffer;
+
+        $stream_buffer->print($chunk)
+            || die sprintf "Failed to write %d bytes to psgi.input file: $!", length( $chunk );
     }
 
     # Ok, we read the body.  Lets play nice for any PSGI app down the pipe


### PR DESCRIPTION
This is a partial fix for catching errors when writing to the pgsi.input file.  Will die if there's an error on write.   This is to address the potential DoS by filling up the temp partition blocking all other requests with a body.

I say "partial" because this also needs to be fixed in HTTP::Body, where it also fails to check for errors.