### PR TITLE
Fix fragment escaping and positioning in uri_for

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -2089,6 +2089,8 @@ konobi: Scott McWhirter <konobi@cpan.org>
 
 marcus: Marcus Ramberg <mramberg@cpan.org>
 
+Mischa Spiegelmock <revmischa@cpan.org>
+
 miyagawa: Tatsuhiko Miyagawa <miyagawa@bulknews.net>
 
 mgrimes: Mark Grimes <mgrimes@cpan.org>

--- a/lib/Catalyst.pm
+++ b/lib/Catalyst.pm
@@ -1632,6 +1632,12 @@ sub uri_for {
 
     my $query = '';
 
+    # remove and save fragment if there is one
+    my $fragment;
+    if ($args =~ s/(#.+)$//) {
+      $fragment = $1;
+    }
+
     if (my @keys = keys %$params) {
       # somewhat lifted from URI::_query's query_form
       $query = '?'.join('&', map {
@@ -1660,7 +1666,10 @@ sub uri_for {
     $base =~ s/([^$URI::uric])/$URI::Escape::escapes{$1}/go;
     $args = encode_utf8 $args;
     $args =~ s/([^$URI::uric])/$URI::Escape::escapes{$1}/go;
-    
+
+    # re-attach fragment on the end of everything after adding params
+    $query .= $fragment if $fragment;
+
     my $res = bless(\"${base}${args}${query}", $class);
     $res;
 }

--- a/t/aggregate/unit_core_uri_for.t
+++ b/t/aggregate/unit_core_uri_for.t
@@ -59,14 +59,11 @@ is(
     'Plus is not encoded'
 );
 
-TODO: {
-    local $TODO = 'broken by 5.7008';
-    is(
-        Catalyst::uri_for( $context, '/bar#fragment', { param1 => 'value1' } )->as_string,
-        'http://127.0.0.1/foo/bar?param1=value1#fragment',
-        'URI for path with fragment and query params'
-    );
-}
+is(
+    Catalyst::uri_for( $context, '/bar#fragment', { param1 => 'value1' } )->as_string,
+    'http://127.0.0.1/foo/bar?param1=value1#fragment',
+    'URI for path with fragment and query params'
+);
 
 # test with utf-8
 is(


### PR DESCRIPTION
Fragment octothorp marker (`#`) was getting improperly escaped, and param query strings were being concatenated to the fragment which is incorrect. Now the fragment is saved and re-attached at the end of the URI untouched.
This fixes a long-standing TODO broken test. Also my application.