### PR TITLE
Fix handling of empty paths in uri_for

### DIFF
--- a/lib/Catalyst.pm
+++ b/lib/Catalyst.pm
@@ -1559,7 +1559,7 @@ sub uri_for {
 
     my $fragment =  ((scalar(@args) && ref($args[-1]) eq 'SCALAR') ? pop @args : undef );
 
-    unless(blessed $path) {
+    if ($path && !(blessed $path)) {
       if ($path =~ s/#(.+)$//)  {
         if(defined($1) and $fragment) {
           carp "Abiguious fragment declaration: You cannot define a fragment in '$path' and as an argument '$fragment'";

--- a/t/aggregate/unit_core_uri_for.t
+++ b/t/aggregate/unit_core_uri_for.t
@@ -128,6 +128,15 @@ is(
     is( $warnings, 0, "no warnings emitted" );
 }
 
+# test with empty path -- no warnings should be thrown
+{
+    my $warnings = 0;
+    local $SIG{__WARN__} = sub { $warnings++ };
+
+    Catalyst::uri_for( $context )->as_string,
+    is( $warnings, 0, "no warnings emitted for empty path" );
+}
+
 # Test with parameters '/', 'foo', 'bar' - should not generate a //
 is( Catalyst::uri_for( $context, qw| / foo bar | )->as_string,
     'http://127.0.0.1/foo/bar', 'uri is /foo/bar, not //foo/bar'


### PR DESCRIPTION
In versions of Catalyst before 5.90097, it was possible to call `uri_for`
with an empty path and receive the URI of the relevant action (as mentioned
in the documentation for `uri_for`).  From version 5.90097, this caused the
following warning (with large backtrace) to be thrown:

    Use of uninitialized value $path in substitution (s///) at
    $HOME/perl5/perlbrew/perls/perl-5.18.4/lib/site_perl/5.18.4/Catalyst.pm
    line 1564.

This was because even though the `$path` wasn't blessed, it hadn't been
initialised to any value and thus was throwing a warning on the substitution
operation.

This change reinstates the previous behaviour (which is still documented in
current versions) and adds a test to protect against future regressions.