### PR TITLE
Fix spelling errors and update spelling exceptions

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -1502,7 +1502,7 @@ This has been done since not all people need this feature and we wish to restric
 
 - `skip_complex_post_part_handling`
 
-    When creating body parameters from a POST, if we run into a multpart POST
+    When creating body parameters from a POST, if we run into a multipart POST
     that does not contain uploads, but instead contains inlined complex data
     (very uncommon) we cannot reliably convert that into field => value pairs.  So
     instead we create an instance of [Catalyst::Request::PartData](https://metacpan.org/pod/Catalyst::Request::PartData).  If this causes
@@ -1522,7 +1522,7 @@ This has been done since not all people need this feature and we wish to restric
     If true, then do not try to character decode any wide characters in your
     request URL query or keywords.  Most readings of the relevant specifications
     suggest these should be UTF-\* encoded, which is the default that [Catalyst](https://metacpan.org/pod/Catalyst)
-    will use, hwoever if you are creating a lot of URLs manually or have external
+    will use, however if you are creating a lot of URLs manually or have external
     evil clients, this might cause you trouble.  If you find the changes introduced
     in Catalyst version 5.90080+ break some of your query code, you may disable 
     the UTF-8 decoding globally using this configuration.
@@ -1533,7 +1533,7 @@ This has been done since not all people need this feature and we wish to restric
 - `default_query_encoding`
 
     By default we decode query and keywords in your request URL using UTF-8, which
-    is our reading of the relevent specifications.  This setting allows one to
+    is our reading of the relevant specifications.  This setting allows one to
     specify a fixed value for how to decode your query.  You might need this if
     you are doing a lot of custom encoding of your URLs and not using UTF-8.
 
@@ -1558,15 +1558,15 @@ This has been done since not all people need this feature and we wish to restric
 - `data_handlers` - See ["DATA HANDLERS"](#data-handlers).
 - `stats_class_traits`
 
-    An arrayref of [Moose::Role](https://metacpan.org/pod/Moose::Role)s that get componsed into your stats class.
+    An arrayref of [Moose::Role](https://metacpan.org/pod/Moose::Role)s that get composed into your stats class.
 
 - `request_class_traits`
 
-    An arrayref of [Moose::Role](https://metacpan.org/pod/Moose::Role)s that get componsed into your request class.
+    An arrayref of [Moose::Role](https://metacpan.org/pod/Moose::Role)s that get composed into your request class.
 
 - `response_class_traits`
 
-    An arrayref of [Moose::Role](https://metacpan.org/pod/Moose::Role)s that get componsed into your response class.
+    An arrayref of [Moose::Role](https://metacpan.org/pod/Moose::Role)s that get composed into your response class.
 
 - `inject_components`
 

--- a/lib/Catalyst.pm
+++ b/lib/Catalyst.pm
@@ -2812,7 +2812,7 @@ We try each possible role in turn (and throw an error if none load)
     MyApp::TraitFor::Request::Foo
     Catalyst::TraitFor::Request::Foo
 
-The namespace part 'TraitFor::Request' was choosen to assist in backwards
+The namespace part 'TraitFor::Request' was chosen to assist in backwards
 compatibility with L<CatalystX::RoleApplicator> which previously provided
 these features in a stand alone package.
   
@@ -2843,7 +2843,7 @@ We try each possible role in turn (and throw an error if none load)
     MyApp::TraitFor::Response::Foo
     Catalyst::TraitFor::Responset::Foo
 
-The namespace part 'TraitFor::Response' was choosen to assist in backwards
+The namespace part 'TraitFor::Response' was chosen to assist in backwards
 compatibility with L<CatalystX::RoleApplicator> which previously provided
 these features in a stand alone package.
 
@@ -4031,7 +4031,7 @@ We try each possible role in turn (and throw an error if none load)
     MyApp::TraitFor::Stats::Foo
     Catalyst::TraitFor::Stats::Foo
 
-The namespace part 'TraitFor::Stats' was choosen to assist in backwards
+The namespace part 'TraitFor::Stats' was chosen to assist in backwards
 compatibility with L<CatalystX::RoleApplicator> which previously provided
 these features in a stand alone package.
 
@@ -4245,7 +4245,7 @@ backwardly compatible).
 
 C<skip_complex_post_part_handling>
 
-When creating body parameters from a POST, if we run into a multpart POST
+When creating body parameters from a POST, if we run into a multipart POST
 that does not contain uploads, but instead contains inlined complex data
 (very uncommon) we cannot reliably convert that into field => value pairs.  So
 instead we create an instance of L<Catalyst::Request::PartData>.  If this causes
@@ -4267,9 +4267,9 @@ parameter to true.
 C<do_not_decode_query>
 
 If true, then do not try to character decode any wide characters in your
-request URL query or keywords.  Most readings of the relevent specifications
+request URL query or keywords.  Most readings of the relevant specifications
 suggest these should be UTF-* encoded, which is the default that L<Catalyst>
-will use, hwoever if you are creating a lot of URLs manually or have external
+will use, however if you are creating a lot of URLs manually or have external
 evil clients, this might cause you trouble.  If you find the changes introduced
 in Catalyst version 5.90080+ break some of your query code, you may disable 
 the UTF-8 decoding globally using this configuration.
@@ -4282,7 +4282,7 @@ C<decode_query_using_global_encoding>
 C<default_query_encoding>
 
 By default we decode query and keywords in your request URL using UTF-8, which
-is our reading of the relevent specifications.  This setting allows one to
+is our reading of the relevant specifications.  This setting allows one to
 specify a fixed value for how to decode your query.  You might need this if
 you are doing a lot of custom encoding of your URLs and not using UTF-8.
 
@@ -4319,19 +4319,19 @@ C<data_handlers> - See L<DATA HANDLERS>.
 
 C<stats_class_traits>
 
-An arrayref of L<Moose::Role>s that get componsed into your stats class.
+An arrayref of L<Moose::Role>s that get composed into your stats class.
 
 =item *
 
 C<request_class_traits>
 
-An arrayref of L<Moose::Role>s that get componsed into your request class.
+An arrayref of L<Moose::Role>s that get composed into your request class.
 
 =item *
 
 C<response_class_traits>
 
-An arrayref of L<Moose::Role>s that get componsed into your response class.
+An arrayref of L<Moose::Role>s that get composed into your response class.
 
 =item *
 

--- a/lib/Catalyst/Action.pm
+++ b/lib/Catalyst/Action.pm
@@ -105,7 +105,7 @@ has number_of_args_constraints => (
         return 1; # Its a normal 1 arg type constraint.
       }
     } else {
-      # We need to loop thru and error on ref types.  We don't allow a ref type
+      # We need to loop through and error on ref types.  We don't allow a ref type
       # in the middle.
       my $total = 0;
       foreach my $tc( @{$self->args_constraints}) {
@@ -190,7 +190,7 @@ has number_of_captures_constraints => (
         return 1; # Its a normal 1 arg type constraint.
       }
     } else {
-      # We need to loop thru and error on ref types.  We don't allow a ref type
+      # We need to loop through and error on ref types.  We don't allow a ref type
       # in the middle.
       my $total = 0;
       foreach my $tc( @{$self->captures_constraints}) {
@@ -266,7 +266,7 @@ sub resolve_type_constraint {
     my @supers = $self->class->can('meta') ? map { $_->meta } $self->class->meta->superclasses : ();
     my @roles = $self->class->can('meta') ? $self->class->meta->calculate_all_roles : ();
 
-    # So look thru all the super and roles in order and return the
+    # So look through all the super and roles in order and return the
     # first type constraint found. We should probably find all matching
     # type constraints and try to do some sort of resolution.
 
@@ -523,7 +523,7 @@ Does the Args match or not?
 
 =head2 resolve_type_constraint
 
-Trys to find a type constraint if you have on on a type constrained method.
+Tries to find a type constraint if you have on on a type constrained method.
 
 =head2 compare
 

--- a/lib/Catalyst/Component.pm
+++ b/lib/Catalyst/Component.pm
@@ -203,8 +203,8 @@ something like this:
   }
 
 B<NOTE:> Generally when L<Catalyst> starts, it initializes all the components
-and passes the hashref present in any configutation information to the
-COMPONET method.  For example
+and passes the hashref present in any configuration information to the
+COMPONENT method.  For example
 
     MyApp->config(
       'Model::Foo' => {
@@ -294,7 +294,7 @@ second argument is blessed (is a context) or not (is an application class name) 
 it MUST return something valid for the case when the scope is application.  This is
 required because a component maybe be called from the application scope even if it
 requires a context and you must prevent errors from being issued if this happens.
-Remeber not all components that ACCEPT_CONTEXT actually need or use context information
+Remember not all components that ACCEPT_CONTEXT actually need or use context information
 (and there is a school of thought that suggestions doing so is a design error anyway...)
 
 =head1 SEE ALSO

--- a/lib/Catalyst/Contributing.pod
+++ b/lib/Catalyst/Contributing.pod
@@ -2,7 +2,7 @@
 
 =head1 Name
 
-Catalyst::Contributing - Contributing to Catalyst and Change managment
+Catalyst::Contributing - Contributing to Catalyst and Change management
 
 =head1 Description
 
@@ -23,7 +23,7 @@ Going further, if we allow ourselves to look hard at projects outside of Perl we
 
 =head2 Reporting a bug
 
-Reported bugs via RT or L<Github Issues|https://github.com/perl-catalyst/catalyst-runtime/issues> that come with attached test cases will be more likely addressed quickly than those that do not.  Proposing a bugfix patch is also alwaysvery welcomed, although it is recommended to stick as closely as possible to an actual bug (rather than a feature change) and to not include unneeded changes in your patch such as formatting corrections.  In any case it is recommended before spending a lot of time on a patch to discuss the issue and your proposed solution, else you risk spending a lot of time on code that may not get merged, which tends to be frustrating.
+Reported bugs via RT or L<Github Issues|https://github.com/perl-catalyst/catalyst-runtime/issues> that come with attached test cases will be more likely addressed quickly than those that do not.  Proposing a bugfix patch is also always very welcome, although it is recommended to stick as closely as possible to an actual bug (rather than a feature change) and to not include unneeded changes in your patch such as formatting corrections.  In any case it is recommended before spending a lot of time on a patch to discuss the issue and your proposed solution, else you risk spending a lot of time on code that may not get merged, which tends to be frustrating.
 
 For bug patches you should create a new branch from the current master.
 

--- a/lib/Catalyst/Controller.pm
+++ b/lib/Catalyst/Controller.pm
@@ -900,7 +900,7 @@ declared attributes you must quote them:
 
 If you use 'reference' type constraints (such as ArrayRef[Int]) that have an unknown
 number of allowed matches, we set this the same way "Args" is.  Please keep in mind
-that actions with an undetermined number of args match at lower precidence than those
+that actions with an undetermined number of args match at lower precedence than those
 with a fixed number.  You may use reference types such as Tuple from L<Types::Standard>
 that allows you to fix the number of allowed args.  For example Args(Tuple[Int,Int])
 would be determined to be two args (or really the same as Args(Int,Int).)  You may

--- a/lib/Catalyst/Delta.pod
+++ b/lib/Catalyst/Delta.pod
@@ -13,12 +13,12 @@ Support for type constraints in Args and CaptureArgs has been improved.  You may
 now inherit from a base controller that declares type constraints and use roles
 that declare type constraints.  See L<Catalyst::RouteMatching> for more.
 
-You may now. also use a full type constraint namespace instead of inporting type
+You may now. also use a full type constraint namespace instead of importing type
 constraints into your package namespace.
 
 We changed the way the middleware stash works so that it no longer localizes
 the PSGI env hashref.  This was done to fix bugs where people set PSGI ENV hash
-keys and found them to dissappear in certain cases.  It also means that now if
+keys and found them to disappear in certain cases.  It also means that now if
 a sub applications sets stash variables, that stash will now bubble up to the
 parent application.  This may be a breaking change for you since previous
 versions of this code did not allow that.  A workaround is to explicitly delete
@@ -65,7 +65,7 @@ you used to check for the object you might find that code is no longer needed
 
 =head3 'case_sensitive' configuration
 
-At one point in time we allowed you to set a 'case_sensitive' configuraion value so
+At one point in time we allowed you to set a 'case_sensitive' configuration value so
 that you could find actions by their private names using mixed case.  We highly
 discourage that.  If you are using this 'feature' you should be on notice that we
 plan to remove the code around it in the near future.
@@ -108,7 +108,7 @@ any subclasses.  For example:
       'Model::Foo' => { a => 100 },
     });
 
-Injected components are useful to reduce the ammount of nearly empty boilerplate classes
+Injected components are useful to reduce the amount of nearly empty boilerplate classes
 you might have, particularly when first starting an application.
 
 =head3 Component setup changes.
@@ -199,7 +199,7 @@ Plack middleware to aid in backwards compatibility.
 
 =head3 Distinguish between body null versus undef.
 
-We also now more carefully distingush the different between a body set
+We also now more carefully distinguish the different between a body set
 to '' and a body that is undef.  This might lead to situations where
 again you'll get a content-length were you didn't get one before or
 where a supporting server will start chunking output.  If this is an
@@ -208,7 +208,7 @@ or report specific problems to the dev team.
 
 =head3 More Catalyst Middleware
 
-We have started migrating code in Catalyst to equivilent Plack
+We have started migrating code in Catalyst to equivalent Plack
 Middleware when such exists and is correct to do so.  For example we now use
 L<Plack::Middleware::ContentLength> to determine content length of a response
 when none is provided.  This replaces similar code inlined with L<Catalyst>

--- a/lib/Catalyst/Middleware/Stash.pm
+++ b/lib/Catalyst/Middleware/Stash.pm
@@ -61,7 +61,7 @@ We store a coderef under the C<PSGI_KEY> which can be dereferenced with
 key values or nothing to access the underlying hashref.
 
 Anything placed into the stash will be available in the stash of any 'mounted'
-Catalyst applictions.  A mounted Catalyst application may set the stash and
+Catalyst applications.  A mounted Catalyst application may set the stash and
 'pass back' information to the parent application.  Non Catalyst applications
 may use this middleware to access and set stash values.
 

--- a/lib/Catalyst/RouteMatching.pod
+++ b/lib/Catalyst/RouteMatching.pod
@@ -25,7 +25,7 @@ that if the request is '/foo/bar/baz' That means the action 'baz' matches:
     sub bar :Path('bar') Args(1) { ...}
     sub baz :Path('bar/baz') Args(0) { ... }
 
-Path length matches take precidence over all other types of matches (included HTTP
+Path length matches take precedence over all other types of matches (included HTTP
 Method, Scheme, etc.).  The same holds true for Chained actions.  Generally the
 chain that matches the most PathParts wins.
 
@@ -37,7 +37,7 @@ action with 'Args' always get the last chance to match.
 
 =head2 When two or more actions match a given Path
 
-Sometimes two or more actions match the same path and all have the same pathpart
+Sometimes two or more actions match the same path and all have the same PathPart
 length.  For example:
 
     package MyApp::Controller::Root;
@@ -80,7 +80,7 @@ your 'catchall' actions higher in the controller.
 =head2 Type Constraints in Args and Capture Args
 
 Beginning in Version 5.90090+ you may use L<Moose>, L<MooseX::Types> or L<Type::Tiny>
-type constraints to futher declare allowed matching for Args or CaptureArgs.  Here
+type constraints to further declare allowed matching for Args or CaptureArgs.  Here
 is a simple example:
 
     package MyApp::Controller::User;
@@ -264,7 +264,7 @@ and interests.
 =head3 Match order when more than one Action matches a path.
 
 As previously described, L<Catalyst> will match 'the longest path', which generally means
-that named path / path_parts will take precidence over Args or CaptureArgs.  However, what
+that named path / path_parts will take precedence over Args or CaptureArgs.  However, what
 will happen if two actions match the same path with equal args?  For example:
 
     sub an_int :Path(user) Args(Int) {
@@ -286,7 +286,7 @@ action NEVER gets hit.  You would need to reverse the order:
 
 Now requests that match this path would first hit the 'an_int' action and will check to see if
 the argument is an integer.  If it is, then the action will execute, otherwise it will pass and
-the dispatcher will check the next matching action (in this case we fall thru to the 'an_any'
+the dispatcher will check the next matching action (in this case we fall through to the 'an_any'
 action).
 
 =head3 Type Constraints and Chained Actions
@@ -327,7 +327,7 @@ well as Args.  For Example:
 
       sub int_priority_link3 :Chained(link_tuple) PathPart('') Args(Int) {  }
 
-These chained actions migth create match tables like the following:
+These chained actions might create match tables like the following:
 
     [debug] Loaded Chained actions:
     .-------------------------------------+--------------------------------------.
@@ -376,7 +376,7 @@ the rule described in the previous section should be followed, which is that L<C
 will start with the last defined action and work upward.  For example the action C<int_priority_chain>
 would be checked before C<any_priority_chain>.  The same applies for actions that are midway links
 in a longer chain.  In this case C<link_int> would be checked before C<link_any>.  So as always we
-recommend that you place you priority or most constrainted actions last and you least or catch-all
+recommend that you place you priority or most constrained actions last and you least or catch-all
 actions first.
 
 Although this reverse order checking may seen counter intuitive it does have the added benefit that

--- a/lib/Catalyst/UTF8.pod
+++ b/lib/Catalyst/UTF8.pod
@@ -315,7 +315,7 @@ an instance of an object L<Catalyst::Request::PartData> which will contain all t
 information needed for you to perform custom parser of the data.
 
 Ideally we'd fix L<Catalyst> to be smarter about decoding so please submit your cases of
-this so we can add inteligence to the parser and find a way to extract a valid value out
+this so we can add intelligence to the parser and find a way to extract a valid value out
 of it.
 
 =head1 UTF8 Encoding in Body Response

--- a/lib/Catalyst/Upgrading.pod
+++ b/lib/Catalyst/Upgrading.pod
@@ -6,7 +6,7 @@ Catalyst::Upgrading - Instructions for upgrading to the latest Catalyst
 
 We changed the way the middleware stash works so that it no longer localizes
 the PSGI env hashref.  This was done to fix bugs where people set PSGI ENV hash
-keys and found them to dissappear in certain cases.  It also means that now if
+keys and found them to disappear in certain cases.  It also means that now if
 a sub applications sets stash variables, that stash will now bubble up to the
 parent application.  This may be a breaking change for you since previous
 versions of this code did not allow that.  A workaround is to explicitly delete
@@ -69,10 +69,10 @@ reports are very welcomed.
 L<Catalyst::Utils> has a new method 'inject_component' which works the same as the method of
 the same name in L<CatalystX::InjectComponent>.  You should start converting any
 use of the non core method in your code as future changes to Catalyst will be
-sychronized to the core method first.  We reserve the right to cease support
+synchronized to the core method first.  We reserve the right to cease support
 of the non core version should we reach a point in time where it cannot be
 properly supported as an external module.  Luckily this should be a trivial
-search and replace.  Change all occurances of:
+search and replace.  Change all occurences of:
 
     CatalystX::InjectComponent->inject(...)
 
@@ -141,8 +141,8 @@ and now in core:
       },
     );
 
-Although the cored behavior requires more code, its better separates concerns
-as well as plays more into core Catalyst expections of how configuration shoul
+Although the core behavior requires more code, it better separates concerns
+as well as plays more into core Catalyst expectations of how configuration should
 look.
 
 Also we added a new develop console mode only warning when you call a component
@@ -218,16 +218,16 @@ that will revert you code to the previous behavior.
 
 =head2 More backwards compatibility options with UTF-8 changes
 
-In order to give better backwards compatiblity with the 5.90080+ UTF-8 changes
+In order to give better backwards compatibility with the 5.90080+ UTF-8 changes
 we've added several configuration options around control of how we try to decode
 your URL keywords / query parameters.
 
 C<do_not_decode_query>
 
 If true, then do not try to character decode any wide characters in your
-request URL query or keywords.  Most readings of the relevent specifications
+request URL query or keywords.  Most readings of the relevant specifications
 suggest these should be UTF-* encoded, which is the default that L<Catalyst>
-will use, hwoever if you are creating a lot of URLs manually or have external
+will use, however if you are creating a lot of URLs manually or have external
 evil clients, this might cause you trouble.  If you find the changes introduced
 in Catalyst version 5.90080+ break some of your query code, you may disable 
 the UTF-8 decoding globally using this configuration.
@@ -238,7 +238,7 @@ C<decode_query_using_global_encoding>
 C<default_query_encoding>
 
 By default we decode query and keywords in your request URL using UTF-8, which
-is our reading of the relevent specifications.  This setting allows one to
+is our reading of the relevant specifications.  This setting allows one to
 specify a fixed value for how to decode your query.  You might need this if
 you are doing a lot of custom encoding of your URLs and not using UTF-8.
 

--- a/t/author/spelling.t
+++ b/t/author/spelling.t
@@ -12,7 +12,7 @@ add_stopwords(qw(
     fastcgi nginx Lighttpd IIS middlewares backend IRC IOLayer
     ctx _application MyApp restarter httponly Utils stash's unescapes
     actionchain dispatchtype dispatchtypes redispatch redispatching
-    CaptureArgs ChainedParent PathPart PathPrefix
+    CaptureArgs ChainedParent PathPart PathParts PathPrefix
     BUILDARGS metaclass namespaces pre ARGV ReverseProxy TT UI
     filename tempname request's subdirectory ini uninstalled uppercased
     wiki bitmask uri url urls dir hostname proxied http https IP SSL
@@ -22,7 +22,7 @@ add_stopwords(qw(
     UTF unicode async codebase dev encodable filenames params MyMiddleware Sendfile
     JSON xml POSTs POSTed RESTful performant subref actionrole
     chunked chunking codewise distingush equivilent plack Javascript gzipping
-    ConfigLoader getline whitepaper matchable
+    ConfigLoader getline whitepaper matchable TBD WIP
     Andreas
     André
     Ashton
@@ -74,6 +74,7 @@ add_stopwords(qw(
     Rodland
     Ruthven
     Sascha
+    Scala
     Schutz
     Sedlacek
     Sheidlower
@@ -91,10 +92,13 @@ add_stopwords(qw(
     Yuval
     abraxxa
     abw
+    alls
+    andrewalker
     andyg
     audreyt
     bricas
     chansen
+    codebases
     davewood
     dhoss
     dkubb
@@ -116,6 +120,7 @@ add_stopwords(qw(
     mgrimes
     miyagawa
     mst
+    multipart
     Napiorkowski
     naughton
     ningu
@@ -127,6 +132,7 @@ add_stopwords(qw(
     rainboxx
     sri
     szbalint
+    uploadtmp
     vanstyn
     willert
     wreis


### PR DESCRIPTION
This change makes the `spelling.t` test pass again by fixing all spelling
errors found as well as adding any words to the exception list which weren't
actually spelling errors.