### PR TITLE
Parse attr empty paren as undef - rebased and cleaned up

### DIFF
--- a/lib/Catalyst/Action.pm
+++ b/lib/Catalyst/Action.pm
@@ -52,9 +52,7 @@ has number_of_args => (
     if( ! exists $self->attributes->{Args} ) {
       # When 'Args' does not exist, that means we want 'any number of args'.
       return undef;
-    } elsif(
-      !defined($self->attributes->{Args}[0]) || 
-      $self->attributes->{Args}[0] eq '' ) {
+    } elsif(!defined($self->attributes->{Args}[0])) {
       # When its 'Args' that internal cue for 'unlimited'
       return undef;
     } elsif(
@@ -140,7 +138,6 @@ has args_constraints => (
 
     return [] unless scalar(@arg_protos);
     return [] unless defined($arg_protos[0]);
-    return [] if ($arg_protos[0] eq '' && scalar(@arg_protos) == 1);
 
     # If there is only one arg and it looks like a number
     # we assume its 'classic' and the number is the number of

--- a/lib/Catalyst/Action.pm
+++ b/lib/Catalyst/Action.pm
@@ -461,7 +461,7 @@ sub scheme {
 sub list_extra_info {
   my $self = shift;
   return {
-    Args => $self->normalized_arg_number,
+    Args => $self->attributes->{Args}[0],
     CaptureArgs => $self->number_of_captures,
   }
 } 

--- a/lib/Catalyst/Controller.pm
+++ b/lib/Catalyst/Controller.pm
@@ -399,7 +399,7 @@ sub _parse_attrs {
 
         # Parse out :Foo(bar) into Foo => bar etc (and arrayify)
 
-        if ( my ( $key, $value ) = ( $attr =~ /^(.*?)(?:\(\s*(.+?)\s*\))?$/ ) )
+        if ( my ( $key, $value ) = ( $attr =~ /^(.*?)(?:\(\s*(.+?)?\s*\))?$/ ) )
         {
 
             if ( defined $value ) {

--- a/lib/Catalyst/Controller.pm
+++ b/lib/Catalyst/Controller.pm
@@ -399,7 +399,7 @@ sub _parse_attrs {
 
         # Parse out :Foo(bar) into Foo => bar etc (and arrayify)
 
-        if ( my ( $key, $value ) = ( $attr =~ /^(.*?)(?:\(\s*(.*?)\s*\))?$/ ) )
+        if ( my ( $key, $value ) = ( $attr =~ /^(.*?)(?:\(\s*(.+?)\s*\))?$/ ) )
         {
 
             if ( defined $value ) {

--- a/t/args-empty-parens-bug.t
+++ b/t/args-empty-parens-bug.t
@@ -1,0 +1,28 @@
+use warnings;
+use strict;
+use Test::More;
+use FindBin qw< $Bin >;
+use lib "$Bin/lib";
+use constant App => 'TestAppArgsEmptyParens';
+use Catalyst::Test App;
+
+{
+    my $res = request('/chain_base/args/foo/bar');
+    is $res->content, 'Args', "request '/chain_base/args/foo/bar'";
+}
+
+{
+    my $res = request('/chain_base/args_empty/foo/bar');
+    is $res->content, 'Args()', "request '/chain_base/args_empty/foo/bar'";
+}
+
+eval { App->dispatcher->dispatch_type('Chained')->list(App) };
+ok !$@, "didn't die"
+    or diag "Died with: $@";
+like $TestLogger::LOGS[-1], qr{/args\s*\Q(...)\E};
+like $TestLogger::LOGS[-1], qr{/args_empty\s*\Q(...)\E};
+
+done_testing;
+
+__END__
+

--- a/t/lib/TestAppArgsEmptyParens.pm
+++ b/t/lib/TestAppArgsEmptyParens.pm
@@ -1,0 +1,21 @@
+package TestAppArgsEmptyParens::Controller::Root;
+use Moose;
+use MooseX::MethodAttributes;
+
+extends 'Catalyst::Controller';
+
+sub chain_base :Chained(/) PathPart('chain_base') CaptureArgs(0) { }
+
+    sub args        : Chained(chain_base) PathPart('args')       Args   { $_[1]->res->body('Args') }
+    sub args_empty  : Chained(chain_base) PathPart('args_empty') Args() { $_[1]->res->body('Args()') }
+
+TestAppArgsEmptyParens::Controller::Root->config(namespace=>'');
+
+package TestAppArgsEmptyParens;
+use Catalyst;
+use TestLogger;
+
+TestAppArgsEmptyParens->setup;
+TestAppArgsEmptyParens->log( TestLogger->new );
+
+1;


### PR DESCRIPTION
This now applies cleanly against current master, and fixes list_extra_info to provide the real args value rather than the sort-order 'normalized' value. We probably want to look at why that exists at all and at the very least rename it so its usage for sort-order only is more clear, but that can be done separately.

@tsibley please review, it's mostly your work except that the final fix is in a different place

@jjn1056 please check, the normalized thing seems to be yours and using it for list_extra_info seemed strange to me but you should probably eyeball the results to ensure I've not messed up a different bit of undertested debug output :)