### PR TITLE
Regression fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,12 @@ script:
    - cpanm --test-only --metacpan Catalyst::Devel
    - cpanm --test-only --metacpan Catalyst::Action::REST
    - cpanm --test-only --metacpan Catalyst::Component::InstancePerContext
-   - cpanm --verbose --test-only --metacpan Catalyst::Plugin::Session
+   - cpanm --test-only --metacpan Catalyst::Plugin::Session
    - cpanm --test-only --metacpan Catalyst::Plugin::Session::State::Cookie
    - cpanm --test-only --metacpan Catalyst::Plugin::Static::Simple
    - cpanm --test-only --metacpan Catalyst::Plugin::ConfigLoader
+   - cpanm --test-only --metacpan Catalyst::Plugin::ConfigLoader
+   - cpanm --test-only --metacpan Catalyst::Authentication::Credential::HTTP
 
    # Still need to figure out why these fail in travis:
    #- cpanm --test-only --metacpan -v Catalyst::View::Email

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
    - cpanm --test-only --metacpan Catalyst::Devel
    - cpanm --test-only --metacpan Catalyst::Action::REST
    - cpanm --test-only --metacpan Catalyst::Component::InstancePerContext
-   - cpanm --verbose --test-only --metacpan Catalyst::Plugin::Session
+   - cpanm --test-only --metacpan Catalyst::Plugin::Session
    - cpanm --test-only --metacpan Catalyst::Plugin::Session::State::Cookie
    - cpanm --test-only --metacpan Catalyst::Plugin::Static::Simple
    - cpanm --test-only --metacpan Catalyst::Plugin::ConfigLoader

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
    - cpanm --test-only --metacpan Catalyst::Devel
    - cpanm --test-only --metacpan Catalyst::Action::REST
    - cpanm --test-only --metacpan Catalyst::Component::InstancePerContext
-   - cpanm --test-only --metacpan Catalyst::Plugin::Session
+   - cpanm --verbose --test-only --metacpan Catalyst::Plugin::Session
    - cpanm --test-only --metacpan Catalyst::Plugin::Session::State::Cookie
    - cpanm --test-only --metacpan Catalyst::Plugin::Static::Simple
    - cpanm --test-only --metacpan Catalyst::Plugin::ConfigLoader

--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 # This file documents the revision history for Perl extension Catalyst.
 
+5.90103 - 2015-11-06
+  - More documentation fixes (thanks to the debian maintainers and melmothx++)
+  - Fixed the way we parse subroutine attribute values to fix a regression
+    introduced in 5.90102.  This is a recommended upgrade (tsibley++)\
+
 5.90102 - 2015-10-29
   - Better warnings when there's an error reading the psgi.input (billmosley++)
   - Fixed spurious warnings in uri_for when using no arguments (melmothx++ and 

--- a/Changes
+++ b/Changes
@@ -3,7 +3,9 @@
 5.90103 - 2015-11-06
   - More documentation fixes (thanks to the debian maintainers and melmothx++)
   - Fixed the way we parse subroutine attribute values to fix a regression
-    introduced in 5.90102.  This is a recommended upgrade (tsibley++)\
+    introduced in 5.90102.  This is a recommended upgrade (tsibley++, mst++)
+  - Fixed regression around auto actions that escape by throwing an exception
+    which was introduced in the last release.
 
 5.90102 - 2015-10-29
   - Better warnings when there's an error reading the psgi.input (billmosley++)

--- a/lib/Catalyst.pm
+++ b/lib/Catalyst.pm
@@ -180,7 +180,7 @@ sub composed_stats_class {
 __PACKAGE__->_encode_check(Encode::FB_CROAK | Encode::LEAVE_SRC);
 
 # Remember to update this in Catalyst::Runtime as well!
-our $VERSION = '5.90102';
+our $VERSION = '5.90103';
 $VERSION = eval $VERSION if $VERSION =~ /_/; # numify for warning-free dev releases
 
 sub import {

--- a/lib/Catalyst/Action.pm
+++ b/lib/Catalyst/Action.pm
@@ -461,7 +461,8 @@ sub scheme {
 sub list_extra_info {
   my $self = shift;
   return {
-    Args => $self->attributes->{Args}[0],
+    #Args => $self->attributes->{Args}[0],
+    Args => $self->normalized_arg_number,
     CaptureArgs => $self->number_of_captures,
   }
 } 

--- a/lib/Catalyst/Controller.pm
+++ b/lib/Catalyst/Controller.pm
@@ -403,8 +403,7 @@ sub _parse_attrs {
     foreach my $attr (@attrs) {
 
         # Parse out :Foo(bar) into Foo => bar etc (and arrayify)
-
-        if ( my ( $key, $value ) = ( $attr =~ /^(.*?)(?:\(\s*(.+?)?\s*\))?$/ ) )
+        if ( my ( $key, $value ) = ( $attr =~ /^(.*?)(?:\(\s*(.+?)\s*\))?$/ ) )
         {
 
             if ( defined $value ) {

--- a/lib/Catalyst/Controller.pm
+++ b/lib/Catalyst/Controller.pm
@@ -399,7 +399,7 @@ sub _parse_attrs {
 
         # Parse out :Foo(bar) into Foo => bar etc (and arrayify)
 
-        if ( my ( $key, $value ) = ( $attr =~ /^(.*?)(?:\(\s*(.+?)\s*\))?$/ ) )
+        if ( my ( $key, $value ) = ( $attr =~ /^(.*?)(?:\(\s*(.+?)?\s*\))?$/ ) )
         {
 
             if ( defined $value ) {

--- a/lib/Catalyst/Controller.pm
+++ b/lib/Catalyst/Controller.pm
@@ -399,7 +399,7 @@ sub _parse_attrs {
 
         # Parse out :Foo(bar) into Foo => bar etc (and arrayify)
 
-        if ( my ( $key, $value ) = ( $attr =~ /^(.*?)(?:\(\s*(.*?)\s*\))?$/ ) )
+        if ( my ( $key, $value ) = ( $attr =~ /^(.*?)(?:\(\s*(.+?)\s*\))?$/ ) )
         {
 
             if ( defined $value ) {

--- a/lib/Catalyst/Controller.pm
+++ b/lib/Catalyst/Controller.pm
@@ -155,6 +155,11 @@ sub _AUTO : Private {
     my ( $self, $c ) = @_;
     my @auto = $c->get_actions( 'auto', $c->namespace );
     foreach my $auto (@auto) {
+        # We FORCE the auto action user to explicitly return
+        # true.  We need to do this since there's some auto
+        # users (Catalyst::Authentication::Credential::HTTP) that
+        # actually do a detach instead.  
+        $c->state(0);
         $auto->dispatch( $c );
         return 0 unless $c->state;
     }

--- a/lib/Catalyst/Controller.pm
+++ b/lib/Catalyst/Controller.pm
@@ -399,7 +399,7 @@ sub _parse_attrs {
 
         # Parse out :Foo(bar) into Foo => bar etc (and arrayify)
 
-        if ( my ( $key, $value ) = ( $attr =~ /^(.*?)(?:\(\s*(.+?)?\s*\))?$/ ) )
+        if ( my ( $key, $value ) = ( $attr =~ /^(.*?)(?:\(\s*(.*?)\s*\))?$/ ) )
         {
 
             if ( defined $value ) {

--- a/lib/Catalyst/Delta.pod
+++ b/lib/Catalyst/Delta.pod
@@ -7,6 +7,22 @@ Catalyst::Delta - Overview of changes between versions of Catalyst
 This is an overview of the user-visible changes to Catalyst between major
 Catalyst releases.
 
+=head2 VERSION 5.90102 - 5.90103
+
+A significant change is that we now preserve the value of $c->state from action
+to follwoing action.  This gives you a new way to pass a value between actions
+in a chain, for example.   However any 'auto' actions always have $c->state
+forced to be set to 0, which is the way its been for a long time, this way an
+auto action is required to return 1 to pass the match.  It also exists to maintain
+compatibility with anyone that exits an auto action with a detach (which is not a
+documented way to excape matching, but exists in the wild since it worked as a
+side effect of the code for a long time).
+
+Additionally, upon $c->detach we also force set state to 0.
+
+Version 5.90102 contains a version of this change but its considered buggy, so
+that is a version to avoid.
+
 =head2 VERSION 5.90100
 
 Support for type constraints in Args and CaptureArgs has been improved.  You may

--- a/lib/Catalyst/DispatchType/Chained.pm
+++ b/lib/Catalyst/DispatchType/Chained.pm
@@ -97,8 +97,8 @@ sub list {
                   sort { $a->reverse cmp $b->reverse }
                            @{ $self->_endpoints }
                   ) {
-        my $args = $endpoint->attributes->{Args}[0];
-        my @parts = (defined($args) and length($args)) ? ('*') x $args : '...';
+        my $args = $endpoint->list_extra_info->{Args};
+        my @parts = (defined($endpoint->attributes->{Args}[0]) ? (("*") x $args) : '...');
         my @parents = ();
         my $parent = "DUMMY";
         my $extra  = $self->_list_extra_http_methods($endpoint);

--- a/lib/Catalyst/DispatchType/Chained.pm
+++ b/lib/Catalyst/DispatchType/Chained.pm
@@ -97,8 +97,8 @@ sub list {
                   sort { $a->reverse cmp $b->reverse }
                            @{ $self->_endpoints }
                   ) {
-        my $args = $endpoint->list_extra_info->{Args};
-        my @parts = (defined($endpoint->attributes->{Args}[0]) ? (("*") x $args) : '...');
+        my $args = $endpoint->attributes->{Args}[0];
+        my @parts = (defined($args) and length($args)) ? ('*') x $args : '...';
         my @parents = ();
         my $parent = "DUMMY";
         my $extra  = $self->_list_extra_http_methods($endpoint);

--- a/lib/Catalyst/Runtime.pm
+++ b/lib/Catalyst/Runtime.pm
@@ -7,7 +7,7 @@ BEGIN { require 5.008003; }
 
 # Remember to update this in Catalyst as well!
 
-our $VERSION = '5.90102';
+our $VERSION = '5.90103';
 $VERSION = eval $VERSION if $VERSION =~ /_/; # numify for warning-free dev releases
 
 =head1 NAME

--- a/t/state.t
+++ b/t/state.t
@@ -19,7 +19,10 @@ use HTTP::Request::Common;
 
   sub auto :Action {
     my ($self, $c) = @_;
-    Test::More::is($c->state, 'begin'); # default state of 1 is new to 9.0102
+    # Even if a begin returns something, we kill it.  Need to
+    # do this since there's actually people doing detach in
+    # auto and expect that to work the same as 0.
+    Test::More::is($c->state, '0');
     return 'auto';
 
   }


### PR DESCRIPTION
This has a proposed changes for regressions reported in some Catalyst external distributions that arose from a change in 5.90102 in how $c->state preserve or resets itself.  In some cases when an auto action does a detach rather than explicitly returning 0, a state 1 or may be incorrectly inferred.  Change explicitly sets state to 0, and adds documentation to that effect.

I also tweaked the travis build to include the reporting module, to make it easier to avoid the type of regression in the future.  PR passes travis on Perl 5.8 - 5.20  