### PR TITLE
Regress redux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ script:
    - cpanm --test-only --metacpan Catalyst::Plugin::Session::State::Cookie
    - cpanm --test-only --metacpan Catalyst::Plugin::Static::Simple
    - cpanm --test-only --metacpan Catalyst::Plugin::ConfigLoader
+   - cpanm --test-only --metacpan Catalyst::Plugin::ConfigLoader
+   - cpanm --test-only --metacpan Catalyst::Authentication::Credential::HTTP
 
    # Still need to figure out why these fail in travis:
    #- cpanm --test-only --metacpan -v Catalyst::View::Email

--- a/Changes
+++ b/Changes
@@ -1,5 +1,12 @@
 # This file documents the revision history for Perl extension Catalyst.
 
+5.90103 - TBD
+  - More documentation fixes (thanks to the debian maintainers and melmothx++)
+  - Fixed the way we parse subroutine attribute values to fix a regression
+    introduced in 5.90102.  This is a recommended upgrade (tsibley++, mst++)
+  - Fixed regression around auto actions that escape by throwing an exception
+    which was introduced in the last release.
+
 5.90102 - 2015-10-29
   - Better warnings when there's an error reading the psgi.input (billmosley++)
   - Fixed spurious warnings in uri_for when using no arguments (melmothx++ and 

--- a/lib/Catalyst/Controller.pm
+++ b/lib/Catalyst/Controller.pm
@@ -155,6 +155,11 @@ sub _AUTO : Private {
     my ( $self, $c ) = @_;
     my @auto = $c->get_actions( 'auto', $c->namespace );
     foreach my $auto (@auto) {
+        # We FORCE the auto action user to explicitly return
+        # true.  We need to do this since there's some auto
+        # users (Catalyst::Authentication::Credential::HTTP) that
+        # actually do a detach instead.  
+        $c->state(0);
         $auto->dispatch( $c );
         return 0 unless $c->state;
     }

--- a/lib/Catalyst/Delta.pod
+++ b/lib/Catalyst/Delta.pod
@@ -7,6 +7,22 @@ Catalyst::Delta - Overview of changes between versions of Catalyst
 This is an overview of the user-visible changes to Catalyst between major
 Catalyst releases.
 
+=head2 VERSION 5.90102 - 5.90103
+
+A significant change is that we now preserve the value of $c->state from action
+to follwoing action.  This gives you a new way to pass a value between actions
+in a chain, for example.   However any 'auto' actions always have $c->state
+forced to be set to 0, which is the way its been for a long time, this way an
+auto action is required to return 1 to pass the match.  It also exists to maintain
+compatibility with anyone that exits an auto action with a detach (which is not a
+documented way to excape matching, but exists in the wild since it worked as a
+side effect of the code for a long time).
+
+Additionally, upon $c->detach we also force set state to 0.
+
+Version 5.90102 contains a version of this change but its considered buggy, so
+that is a version to avoid.
+
 =head2 VERSION 5.90100
 
 Support for type constraints in Args and CaptureArgs has been improved.  You may

--- a/t/state.t
+++ b/t/state.t
@@ -19,7 +19,10 @@ use HTTP::Request::Common;
 
   sub auto :Action {
     my ($self, $c) = @_;
-    Test::More::is($c->state, 'begin'); # default state of 1 is new to 9.0102
+    # Even if a begin returns something, we kill it.  Need to
+    # do this since there's actually people doing detach in
+    # auto and expect that to work the same as 0.
+    Test::More::is($c->state, '0');
     return 'auto';
 
   }


### PR DESCRIPTION
Fix for reported issue introduced in 5.90102, where if an auto action does a detach instead of return 0, there are cases where the state change in 5.90102 will return 1 instead of 0.

Added to travis the reporting distribution so we can prevent regressions like this in the future.  Now passes on travis: https://travis-ci.org/perl-catalyst/catalyst-runtime/builds/90153493