### PR TITLE
use normalized args to silence warnings in DEBUG mode

### DIFF
--- a/lib/Catalyst/Action.pm
+++ b/lib/Catalyst/Action.pm
@@ -461,7 +461,7 @@ sub scheme {
 sub list_extra_info {
   my $self = shift;
   return {
-    Args => $self->attributes->{Args}[0],
+    Args => $self->normalized_arg_number,
     CaptureArgs => $self->number_of_captures,
   }
 } 

--- a/lib/Catalyst/Action.pm
+++ b/lib/Catalyst/Action.pm
@@ -68,6 +68,10 @@ has number_of_args => (
   }
 
 sub normalized_arg_number {
+  return $_[0]->number_of_args;
+}
+
+sub comparable_arg_number {
   return defined($_[0]->number_of_args) ? $_[0]->number_of_args : ~0;
 }
 
@@ -130,6 +134,7 @@ has args_constraints => (
   handles => {
     has_args_constraints => 'count',
     args_constraint_count => 'count',
+    all_args_constraints => 'elements',
   });
 
   sub _build_args_constraints {
@@ -215,6 +220,7 @@ has captures_constraints => (
   handles => {
     has_captures_constraints => 'count',
     captures_constraints_count => 'count',
+    all_captures_constraints => 'elements',
   });
 
   sub _build_captures_constraints {
@@ -381,8 +387,8 @@ sub match_args {
         # Optimization since Tuple[Int, Int] would fail on 3,4,5 anyway, but this
         # way we can avoid calling the constraint when the arg length is incorrect.
         if(
-          $self->normalized_arg_number == ~0 ||
-          scalar( @args ) == $self->normalized_arg_number
+          $self->comparable_arg_number == ~0 ||
+          scalar( @args ) == $self->comparable_arg_number
         ) {
           return $self->args_constraints->[0]->check($args);
         } else {
@@ -397,7 +403,7 @@ sub match_args {
       } else {
         # Because of the way chaining works, we can expect args that are totally not
         # what you'd expect length wise.  When they don't match length, thats a fail
-        return 0 unless scalar( @args ) == $self->normalized_arg_number;
+        return 0 unless scalar( @args ) == $self->comparable_arg_number;
 
         for my $i(0..$#args) {
           $self->args_constraints->[$i]->check($args[$i]) || return 0;
@@ -406,10 +412,10 @@ sub match_args {
       }
     } else {
       # If infinite args with no constraints, we always match
-      return 1 if $self->normalized_arg_number == ~0;
+      return 1 if $self->comparable_arg_number == ~0;
 
       # Otherwise, we just need to match the number of args.
-      return scalar( @args ) == $self->normalized_arg_number;
+      return scalar( @args ) == $self->comparable_arg_number;
     }
 }
 
@@ -451,7 +457,7 @@ sub match_captures_constraints {
 
 sub compare {
     my ($a1, $a2) = @_;
-    return $a1->normalized_arg_number <=> $a2->normalized_arg_number;
+    return $a1->comparable_arg_number <=> $a2->comparable_arg_number;
 }
 
 sub scheme {
@@ -553,6 +559,12 @@ Returns the number of args this action expects. This is 0 if the action doesn't
 take any arguments and undef if it will take any number of arguments.
 
 =head2 normalized_arg_number
+
+The number of arguments (starting with zero) that the current action defines, or
+undefined if there is not defined number of args (which is later treated as, "
+as many arguments as you like").
+
+=head2 comparable_arg_number
 
 For the purposes of comparison we normalize 'number_of_args' so that if it is
 undef we mean ~0 (as many args are we can think of).

--- a/lib/Catalyst/Controller.pm
+++ b/lib/Catalyst/Controller.pm
@@ -924,6 +924,10 @@ wish to reuse over many actions.
 
 See L<Catalyst::RouteMatching> for more.
 
+B<Note>: It is highly recommended to use L<Type::Tiny> for your type constraints over
+other options.  L<Type::Tiny> exposed a better meta data interface which allows us to
+do more and better types of introspection driving tests and debugging.
+
 =head2 Consumes('...')
 
 Matches the current action against the content-type of the request.  Typically

--- a/t/args-empty-parens-bug.t
+++ b/t/args-empty-parens-bug.t
@@ -19,8 +19,8 @@ use Catalyst::Test App;
 eval { App->dispatcher->dispatch_type('Chained')->list(App) };
 ok !$@, "didn't die"
     or diag "Died with: $@";
-like $TestLogger::LOGS[-1], qr{/args\s*\Q(...)\E};
-like $TestLogger::LOGS[-1], qr{/args_empty\s*\Q(...)\E};
+like $TestLogger::LOGS[-1], qr{chain_base\/args\/\.\.\.};
+like $TestLogger::LOGS[-1], qr{chain_base\/args_empty\/\.\.\.};
 
 done_testing;
 

--- a/t/bad_warnings.t
+++ b/t/bad_warnings.t
@@ -1,0 +1,57 @@
+use warnings;
+use strict;
+use Test::More;
+use HTTP::Request::Common;
+
+# In DEBUG mode, we get not a number warnigs 
+
+my $error;
+
+{
+  package MyApp::Controller::Root;
+  $INC{'MyApp/Controller/Root.pm'} = __FILE__;
+
+  use base 'Catalyst::Controller';
+
+  sub root :Chained(/) PathPrefix CaptureArgs(0) { }
+
+  sub test :Chained(root) Args('"Int"') {
+    my ($self, $c) = @_;
+    $c->response->body("This is the body");
+  }
+
+  sub infinity :Chained(root) PathPart('test') Args { 
+    my ($self, $c) = @_;
+    $c->response->body("This is the body");
+    Test::More::is $c->action->normalized_arg_number, ~0;
+  }
+
+  sub local :Local Args {
+    my ($self, $c) = @_;
+    $c->response->body("This is the body");
+    Test::More::is $c->action->normalized_arg_number, ~0;
+  }
+
+
+  package MyApp;
+  use Catalyst;
+
+  sub debug { 1 }
+
+  $SIG{__WARN__} = sub { $error = shift };
+
+  MyApp->setup;
+}
+
+use Catalyst::Test 'MyApp';
+
+request GET '/root/test/a/b/c';
+request GET '/root/local/a/b/c';
+
+if($error) {
+  unlike($error, qr[Argument ""Int"" isn't numeric in repeat]);
+} else {
+  ok 1;
+}
+
+done_testing(3);

--- a/t/bad_warnings.t
+++ b/t/bad_warnings.t
@@ -23,13 +23,25 @@ my $error;
   sub infinity :Chained(root) PathPart('test') Args { 
     my ($self, $c) = @_;
     $c->response->body("This is the body");
-    Test::More::is $c->action->normalized_arg_number, ~0;
+    Test::More::is $c->action->comparable_arg_number, ~0;
+  }
+
+  sub midpoint :Chained(root) PathPart('') CaptureArgs('"Int"') {
+    my ($self, $c) = @_;
+    Test::More::is $c->action->number_of_captures, 1;
+    #Test::More::is $c->action->number_of_captures_constraints, 1;
+  }
+
+  sub endpoint :Chained('midpoint') Args('"Int"') {
+    my ($self, $c) = @_;
+    Test::More::is $c->action->comparable_arg_number, 1;
+    Test::More::is $c->action->normalized_arg_number, 1;
   }
 
   sub local :Local Args {
     my ($self, $c) = @_;
     $c->response->body("This is the body");
-    Test::More::is $c->action->normalized_arg_number, ~0;
+    Test::More::is $c->action->comparable_arg_number, ~0;
   }
 
 
@@ -47,6 +59,8 @@ use Catalyst::Test 'MyApp';
 
 request GET '/root/test/a/b/c';
 request GET '/root/local/a/b/c';
+request GET '/root/11/endpoint/22';
+
 
 if($error) {
   unlike($error, qr[Argument ""Int"" isn't numeric in repeat]);
@@ -54,4 +68,4 @@ if($error) {
   ok 1;
 }
 
-done_testing(3);
+done_testing(6);


### PR DESCRIPTION
The issue with this change is that in the case where Args is a Type Constraint, it results in silly warnings and incorrect output when CATALYST_DEBUG is on.  This is because we use this value to display '*' for the number of arguments and when this is a string you get a 'can't use string in a repeat error (see test case).

We changed this in commit https://github.com/perl-catalyst/catalyst-runtime/commit/bd6018c40240ca651d1ff62552b948fc9e691cab

which was possible done because of the issue when Args is undefined thats the cue for 'infinite' and that lead to an out of memory error when CATALYST_DEBUG was true.  HOWEVER the code used to display the argument count doesn't blindly use the Args count, it checks to see if this is undefined first, so this is no longer a problem (see https://github.com/perl-catalyst/catalyst-runtime/blob/master/lib/Catalyst/DispatchType/Chained.pm#L100)

Basically ->list_extra_info->{Args} needs to be a number or undefined based on its usage.  If we don't want to use ->normalized_arg_number because that can be ~0 we can do something here that tests the attribute to see if its a number or not and does the right thing or not.  Current setup spews warnings all over my logs and messes up the DEBUG display 