### PR TITLE
Fix file uploads with utf8 form field names. RT#113486

### DIFF
--- a/lib/Catalyst/Engine.pm
+++ b/lib/Catalyst/Engine.pm
@@ -650,8 +650,8 @@ sub prepare_uploads {
     my $uploads = $request->_body->upload;
     my $parameters = $request->parameters;
     foreach my $name (keys %$uploads) {
-        $name = $c->_handle_unicode_decoding($name) if $enc;
         my $files = $uploads->{$name};
+        $name = $c->_handle_unicode_decoding($name) if $enc;
         my @uploads;
         for my $upload (ref $files eq 'ARRAY' ? @$files : ($files)) {
             my $headers = HTTP::Headers->new( %{ $upload->{headers} } );


### PR DESCRIPTION
Don't decode the name (possibly changing its data) before using it
to do a hash lookup.