### PR TITLE
Prevent handle param error when no encoding is specified

### DIFF
--- a/lib/Catalyst.pm
+++ b/lib/Catalyst.pm
@@ -124,7 +124,7 @@ sub _build_response_constructor_args {
 sub composed_response_class {
   my $class = shift;
   return $class->_composed_response_class if $class->_composed_response_class;
-  
+
   my @traits = (@{$class->response_class_traits||[]}, @{$class->config->{response_class_traits}||[]});
 
   my $trait_ns = 'TraitFor::Response';
@@ -164,7 +164,7 @@ our $RECURSION = 1000;
 our $DETACH    = Catalyst::Exception::Detach->new;
 our $GO        = Catalyst::Exception::Go->new;
 
-#I imagine that very few of these really 
+#I imagine that very few of these really
 #need to be class variables. if any.
 #maybe we should just make them attributes with a default?
 __PACKAGE__->mk_classdata($_)
@@ -1436,9 +1436,9 @@ EOF
         }
 
         my @middleware = map {
-          ref $_ eq 'CODE' ? 
-            "Inline Coderef" : 
-              (ref($_) .'  '. ($_->can('VERSION') ? $_->VERSION || '' : '') 
+          ref $_ eq 'CODE' ?
+            "Inline Coderef" :
+              (ref($_) .'  '. ($_->can('VERSION') ? $_->VERSION || '' : '')
                 || '')  } $class->registered_middlewares;
 
         if (@middleware) {
@@ -2307,7 +2307,7 @@ sub finalize_encoding {
     # to do this early since encodable_response is false for this condition and we need
     # to match the debug output for backcompat (there's a test for this...) -JNAP
     if(
-      $res->content_type_charset and $c->encoding and 
+      $res->content_type_charset and $c->encoding and
       (uc($c->encoding->mime_name) ne uc($res->content_type_charset))
     ) {
         my $ct = lc($res->content_type_charset);
@@ -2324,7 +2324,7 @@ sub finalize_encoding {
         $c->res->body( $c->encoding->encode( $c->res->body, $c->_encode_check ) );
 
         # Set the charset if necessary.  This might be a bit bonkers since encodable response
-        # is false when the set charset is not the same as the encoding mimetype (maybe 
+        # is false when the set charset is not the same as the encoding mimetype (maybe
         # confusing action at a distance here..
         # Don't try to set the charset if one already exists or if headers are already finalized
         $c->res->content_type($c->res->content_type . "; charset=" . $c->encoding->mime_name)
@@ -2871,7 +2871,7 @@ We try each possible role in turn (and throw an error if none load)
 The namespace part 'TraitFor::Request' was chosen to assist in backwards
 compatibility with L<CatalystX::RoleApplicator> which previously provided
 these features in a stand alone package.
-  
+
 =head2 $app->composed_request_class
 
 This is the request class which has been composed with any request_class_traits.
@@ -3231,7 +3231,7 @@ sub setup_component {
       $class->components->{ $component } = $class->setup_component($component);
     }
 
-    return $instance; 
+    return $instance;
 }
 
 =head2 $app->config_for( $component_name )
@@ -3356,7 +3356,7 @@ sub setup_engine {
     return;
 }
 
-## This exists just to supply a prebuild psgi app for mod_perl and for the 
+## This exists just to supply a prebuild psgi app for mod_perl and for the
 ## build in server support (back compat support for pre psgi port behavior).
 ## This is so that we don't build a new psgi app for each request when using
 ## the mod_perl handler or the built in servers (http and fcgi, etc).
@@ -3373,7 +3373,7 @@ sub _finalized_psgi_app {
 }
 
 ## Look for a psgi file like 'myapp_web.psgi' (if the app is MyApp::Web) in the
-## home directory and load that and return it (just assume it is doing the 
+## home directory and load that and return it (just assume it is doing the
 ## right thing :) ).  If that does not exist, call $app->psgi_app, wrap that
 ## in default_middleware and return it ( this is for backward compatibility
 ## with pre psgi port behavior ).
@@ -4049,7 +4049,7 @@ sub default_data_handlers {
           my ($fh, $req) = @_;
           my $parser = Class::Load::load_first_existing_class('JSON::MaybeXS', 'JSON');
           my $slurped;
-          return eval { 
+          return eval {
             local $/;
             $slurped = $fh->getline;
             $parser->can("decode_json")->($slurped); # decode_json does utf8 decoding for us
@@ -4336,7 +4336,7 @@ that does not contain uploads, but instead contains inlined complex data
 (very uncommon) we cannot reliably convert that into field => value pairs.  So
 instead we create an instance of L<Catalyst::Request::PartData>.  If this causes
 issue for you, you can disable this by setting C<skip_complex_post_part_handling>
-to true (default is false).  
+to true (default is false).
 
 =item *
 
@@ -4357,7 +4357,7 @@ request URL query or keywords.  Most readings of the relevant specifications
 suggest these should be UTF-* encoded, which is the default that L<Catalyst>
 will use, however if you are creating a lot of URLs manually or have external
 evil clients, this might cause you trouble.  If you find the changes introduced
-in Catalyst version 5.90080+ break some of your query code, you may disable 
+in Catalyst version 5.90080+ break some of your query code, you may disable
 the UTF-8 decoding globally using this configuration.
 
 This setting takes precedence over C<default_query_encoding>
@@ -4574,17 +4574,17 @@ option, C<data_handlers>, which lets you associate a content type with a coderef
 that parses that content type into something Perl can readily access.
 
     package MyApp::Web;
- 
+
     use Catalyst;
     use JSON::Maybe;
- 
+
     __PACKAGE__->config(
       data_handlers => {
         'application/json' => sub { local $/; decode_json $_->getline },
       },
       ## Any other configuration.
     );
- 
+
     __PACKAGE__->setup;
 
 By default L<Catalyst> comes with a generic JSON data handler similar to the
@@ -4610,12 +4610,12 @@ arrayref under the configuration key C<psgi_middleware>.  Here's an example
 with details to follow:
 
     package MyApp::Web;
- 
+
     use Catalyst;
     use Plack::Middleware::StackTrace;
- 
+
     my $stacktrace_middleware = Plack::Middleware::StackTrace->new;
- 
+
     __PACKAGE__->config(
       'psgi_middleware', [
         'Debug',
@@ -4632,7 +4632,7 @@ with details to follow:
         },
       ],
     );
- 
+
     __PACKAGE__->setup;
 
 So the general form is:
@@ -4658,26 +4658,26 @@ middleware will wrap closer to the application).  Keep this in mind since in
 some cases the order of middleware is important.
 
 The two approaches are not exclusive.
- 
+
 =over 4
- 
+
 =item Middleware Object
- 
+
 An already initialized object that conforms to the L<Plack::Middleware>
 specification:
- 
+
     my $stacktrace_middleware = Plack::Middleware::StackTrace->new;
- 
+
     __PACKAGE__->config(
       'psgi_middleware', [
         $stacktrace_middleware,
       ]);
- 
- 
+
+
 =item coderef
- 
+
 A coderef that is an inlined middleware:
- 
+
     __PACKAGE__->config(
       'psgi_middleware', [
         sub {
@@ -4694,11 +4694,11 @@ A coderef that is an inlined middleware:
          },
       },
     ]);
- 
- 
- 
+
+
+
 =item a scalar
- 
+
 We assume the scalar refers to a namespace after normalizing it using the
 following rules:
 
@@ -4729,12 +4729,12 @@ Examples:
         '+MyApp::Custom',  ## MyApp::Custom->wrap
       ],
     );
- 
+
 =item a scalar followed by a hashref
- 
+
 Just like the previous, except the following C<HashRef> is used as arguments
 to initialize the middleware object.
- 
+
     __PACKAGE__->config(
       'psgi_middleware', [
          'Session' => {store => 'File'},

--- a/lib/Catalyst.pm
+++ b/lib/Catalyst.pm
@@ -3654,6 +3654,9 @@ sub _handle_param_unicode_decoding {
     return $value if blessed($value); #don't decode when the value is an object.
 
     my $enc = $self->encoding;
+
+    return $value unless $enc; # don't decode if no encoding is specified
+
     $check ||= $self->_encode_check;
     return try {
       $enc->decode( $value, $check);


### PR DESCRIPTION
With 5.90111, query params are encoded by default. However, if no `encoding` is set, then `_handle_param_unicode_decoding` blows up. So, this PR adds a null check to not do anything if the encoding is not specified.

Background: our app sets the `encoding` to be `undef` because we've had our own custom plugin for handling encoding (for a while now).
