### PR TITLE
Fix parameter debug output with Hash::MultiValue

### DIFF
--- a/lib/Catalyst.pm
+++ b/lib/Catalyst.pm
@@ -2741,9 +2741,16 @@ sub log_request_parameters {
         next if ! keys %$params;
         my $t = Text::SimpleTable->new( [ 35, 'Parameter' ], [ $column_width, 'Value' ] );
         for my $key ( sort keys %$params ) {
-            my $param = $params->{$key};
-            my $value = defined($param) ? $param : '';
-            $t->row( $key, ref $value eq 'ARRAY' ? ( join ', ', @$value ) : $value );
+            my @values = ();
+            if(ref $params eq 'Hash::MultiValue') {
+                @values = $params->get_all($key);
+            } else {
+                my $param = $params->{$key};
+                if( defined($param) ) {
+                    @values = ref $param eq 'ARRAY' ? @$param : $param;
+                }
+            }
+            $t->row( $key.( scalar @values > 1 ? ' [multiple]' : ''), join(', ', @values) );
         }
         $c->log->debug( ucfirst($type) . " Parameters are:\n" . $t->draw );
     }


### PR DESCRIPTION
Fixes debug output of body and query parameters with multiple values when use_hash_multivalue_in_request is used as noticed in #149. Also adds the string "[multiple]" after parameter names with more than one value to distinguish between the value "1, 2, 3" and the array of the same values.