### PR TITLE
Change behaviour for terminal width detection

### DIFF
--- a/lib/Catalyst/Utils.pm
+++ b/lib/Catalyst/Utils.pm
@@ -413,11 +413,14 @@ sub term_width {
           } else {
             warn "There was an error trying to detect your terminal size: $@\n";
           }
+    };
+
+    unless ($width) {
         warn 'Trouble trying to detect your terminal size, looking at $ENV{COLUMNS}'."\n";
         $width = $ENV{COLUMNS}
             if exists($ENV{COLUMNS})
             && $ENV{COLUMNS} =~ m/^\d+$/;
-    };
+    }
 
     do {
       warn "Cannot determine desired terminal width, using default of 80 columns\n";


### PR DESCRIPTION
Sometimes Term::Size::Any is installed but can return a width of
undef. This causes the eval to succeed but then it falls back to
using 80 characters.

This change allows it to look at $ENV{COLUMNS} for a hint if the
width isn't defined or if the eval fails due to a missing module
instead of just if the eval returns an error.