### PR TITLE
Avoid List::MoreUtils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,15 @@ install:
    - cpanm --notest --metacpan --skip-satisfied --installdeps .
    - echo y | perl Makefile.PL
 
+   # installing Catalyst::Devel above causes the latest release of
+   # Catalyst::Runtime to be installed, but the version we're testing might
+   # have additional deps that aren't yet satisfied. so we should try
+   # installing deps again now that the MYMETA has been created (and we'll also
+   # need to delete the now-unneeded cpanfile so that cpanm doesn't choose it
+   # in preference to the MYMETA)
+   - rm -f cpanfile
+   - cpanm --notest --metacpan --skip-satisfied --installdeps .
+
    # enable various test options, including parallel testing
    - export AUTOMATED_TESTING=1 HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,7 @@ author 'Sebastian Riedel <sri@cpan.org>';
 authority('cpan:MSTROUT');
 all_from 'lib/Catalyst/Runtime.pm';
 
-requires 'List::MoreUtils';
+requires 'List::Util' => '1.45'; # for uniq()
 requires 'namespace::autoclean' => '0.28';
 requires 'namespace::clean' => '0.23';
 requires 'MooseX::Emulate::Class::Accessor::Fast' => '0.00903';

--- a/lib/Catalyst.pm
+++ b/lib/Catalyst.pm
@@ -27,7 +27,7 @@ use HTML::Entities;
 use Tree::Simple qw/use_weak_refs/;
 use Tree::Simple::Visitor::FindByUID;
 use Class::C3::Adopt::NEXT;
-use List::MoreUtils qw/uniq/;
+use List::Util qw/uniq/;
 use attributes;
 use String::RewritePrefix;
 use Catalyst::EngineLoader;

--- a/lib/Catalyst/Controller.pm
+++ b/lib/Catalyst/Controller.pm
@@ -5,8 +5,7 @@ use Class::MOP;
 use Class::Load ':all';
 use String::RewritePrefix;
 use Moose::Util qw/find_meta/;
-use List::Util qw/first/;
-use List::MoreUtils qw/uniq/;
+use List::Util qw/first uniq/;
 use namespace::clean -except => 'meta';
 
 BEGIN {


### PR DESCRIPTION
The latest version of this module has a confusing and hard-to-honour set of licences, with different terms for code added in different versions.

The only use we make of it is the `uniq()` function. A routine with the same behaviour is available in newer versions of List::Util, and we already depend on older versions of *that* module. So depending on a recent enough version of List::Util means that this change actually reduces the number of non-core dependencies for users with a new enough version of Perl.