### PR TITLE
Always dereference $fragment: issue #158

### DIFF
--- a/lib/Catalyst.pm
+++ b/lib/Catalyst.pm
@@ -1609,7 +1609,7 @@ sub uri_for {
           carp "Abiguious fragment declaration: You cannot define a fragment in '$path' and as an argument '$fragment'";
         }
         if(defined($1)) {
-          $fragment = $1;
+          $fragment = \"$1";
         }
       }
     }
@@ -1724,8 +1724,8 @@ sub uri_for {
     $args =~ s/([^$URI::uric])/$URI::Escape::escapes{$1}/go;
 
     if(defined $fragment) {
+      $fragment = encode_utf8(${$fragment});
       if(blessed $path) {
-        $fragment = encode_utf8(${$fragment});
         $fragment =~ s/([^A-Za-z0-9\-_.!~*'() ])/$URI::Escape::escapes{$1}/go;
         $fragment =~ s/ /+/g;
       }

--- a/t/aggregate/unit_core_uri_for.t
+++ b/t/aggregate/unit_core_uri_for.t
@@ -17,6 +17,7 @@ my $context = TestApp->new( {
                 namespace => 'yada',
               } );
 
+
 is(
     Catalyst::uri_for( $context, '/bar/baz' )->as_string,
     'http://127.0.0.1/foo/bar/baz',
@@ -67,6 +68,12 @@ is(
 
 is(
     Catalyst::uri_for( $context, '/bar#fragment', { param1 => 'value1' } )->as_string,
+    'http://127.0.0.1/foo/bar?param1=value1#fragment',
+    'URI for path with fragment and query params 1'
+);
+
+is(
+    Catalyst::uri_for( $context, '/bar', { param1 => 'value1' }, \'fragment' )->as_string,
     'http://127.0.0.1/foo/bar?param1=value1#fragment',
     'URI for path with fragment and query params 1'
 );
@@ -289,6 +296,12 @@ TODO: {
 is(
     Catalyst::uri_for( $context, bless( { string => 'test' }, 'MyStringThing' ) ),
     'http://127.0.0.1/test',
+    'overloaded object handled correctly'
+);
+
+is(
+    Catalyst::uri_for( $context, bless( { string => 'test' }, 'MyStringThing' ), \'fragment' ),
+    'http://127.0.0.1/test#fragment',
     'overloaded object handled correctly'
 );
 


### PR DESCRIPTION
We must also ensure that $fragement is a reference when extracted from
the path string. Add relevant tests.