### PR TITLE
Split code to log stats report (RT#127392)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 # This file documents the revision history for Perl extension Catalyst.
 
+  - split code to log stats report into a separate log_stats method (RT#127392)
+
 5.90122 - 2018-11-03
   - releasing as stable
 

--- a/lib/Catalyst.pm
+++ b/lib/Catalyst.pm
@@ -2196,15 +2196,26 @@ sub finalize {
 
     $c->log_response;
 
-    if ($c->use_stats) {
-        my $elapsed = $c->stats->elapsed;
-        my $av = $elapsed == 0 ? '??' : sprintf '%.3f', 1 / $elapsed;
-        $c->log->info(
-            "Request took ${elapsed}s ($av/s)\n" . $c->stats->report . "\n" );
-    }
+    $c->log_stats if $c->use_stats;
 
     return $c->response->status;
 }
+
+=head2 $c->log_stats
+
+Logs statistics.
+
+=cut
+
+sub log_stats {
+    my $c = shift;
+
+    my $elapsed = $c->stats->elapsed;
+    my $av = $elapsed == 0 ? '??' : sprintf '%.3f', 1 / $elapsed;
+    $c->log->info(
+        "Request took ${elapsed}s ($av/s)\n" . $c->stats->report . "\n" );
+}
+
 
 =head2 $c->finalize_body
 
@@ -5010,6 +5021,8 @@ random: Roland Lammel <lammel@cpan.org>
 revmischa: Mischa Spiegelmock <revmischa@cpan.org>
 
 Robert Sedlacek <rs@474.at>
+
+rrwo: Robert Rothenberg <rrwo@cpan.org>
 
 SpiceMan: Marcel Montes
 

--- a/lib/Catalyst/Upgrading.pod
+++ b/lib/Catalyst/Upgrading.pod
@@ -2,6 +2,11 @@
 
 Catalyst::Upgrading - Instructions for upgrading to the latest Catalyst
 
+=head1 Upgrading to Catalyst 5.90121
+
+A new C<log_stats> method has been added. This will only affect
+subclasses that have a method with this name added.
+
 =head1 Upgrading to Catalyst 5.90100
 
 We changed the way the middleware stash works so that it no longer localizes


### PR DESCRIPTION
This change allows the stats to be enabled, but the logging of the report to be overridden. For example, one may want to collect the stats but log them to statsd rather than a textual table in the logs.