### PR TITLE
Fix decoded uploads

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -78,6 +78,7 @@ my %META = (
         "Plack::Middleware::FixMissingBodyInRedirect" => '0.09',
         "Plack::Middleware::MethodOverride" => '0.12',
         "Plack::Middleware::RemoveRedundantBody" => '0.03',
+        'PerlIO::utf8_strict' => 0,
       },
     },
     develop   => {

--- a/lib/Catalyst/Request/Upload.pm
+++ b/lib/Catalyst/Request/Upload.pm
@@ -211,14 +211,20 @@ sub slurp {
         $layer = ':raw';
     }
 
-    my $content = undef;
+    my $content = '';
     my $handle  = $self->fh;
 
     binmode( $handle, $layer );
 
     $handle->seek(0, IO::File::SEEK_SET);
-    while ( $handle->sysread( my $buffer, 8192 ) ) {
-        $content .= $buffer;
+
+    if ($layer eq ':raw') {
+        while ( $handle->sysread( my $buffer, 8192 ) ) {
+            $content .= $buffer;
+        }
+    }
+    else {
+        $content = do { local $/; $handle->getline };
     }
 
     $handle->seek(0, IO::File::SEEK_SET);
@@ -237,11 +243,9 @@ sub decoded_slurp {
     my ( $self, $layer ) = @_;
     my $handle = $self->decoded_fh($layer);
 
-    my $content = undef;
     $handle->seek(0, IO::File::SEEK_SET);
-    while ( $handle->sysread( my $buffer, 8192 ) ) {
-        $content .= $buffer;
-    }
+
+    my $content = do { local $/; $handle->getline };
 
     $handle->seek(0, IO::File::SEEK_SET);
     return $content;

--- a/lib/Catalyst/Request/Upload.pm
+++ b/lib/Catalyst/Request/Upload.pm
@@ -7,6 +7,7 @@ use Catalyst::Exception;
 use File::Copy ();
 use IO::File ();
 use File::Spec::Unix;
+use PerlIO::utf8_strict;
 use namespace::clean -except => 'meta';
 
 has filename => (is => 'rw');
@@ -157,7 +158,7 @@ sub decoded_fh {
     my ($self, $layer) = @_;
     my $fh  = $self->fh;
 
-    $layer = ":encoding(UTF-8)" if !$layer && $self->is_utf8_encoded;
+    $layer = ':utf8_strict' if !$layer && $self->is_utf8_encoded;
     $layer = ':raw' unless $layer;
 
     binmode($fh, $layer);

--- a/t/utf_incoming.t
+++ b/t/utf_incoming.t
@@ -409,9 +409,7 @@ use Catalyst::Test 'MyApp';
   is $res->content_charset, 'UTF-8';
 }
 
-SKIP:
 {
-  skip 'skipped: sysread isn\'t allowed on :utf8 handles (starting with 5.029004)', 4 if $] >= '5.029004';
   ok my $path = File::Spec->catfile('t', 'utf8.txt');
   ok my $req = POST '/root/file_upload',
     Content_Type => 'form-data',
@@ -421,9 +419,7 @@ SKIP:
   is decode_utf8($res->content), "<p>This is stream_body_fh action ♥</p>\n";
 }
 
-SKIP:
 {
-  skip 'skipped: sysread isn\'t allowed on :utf8 handles (starting with 5.029004)', 5 if $] >= '5.029004';
   ok my $path = File::Spec->catfile('t', 'utf8.txt');
   ok my $req = POST '/root/file_upload_utf8_param',
     Content_Type => 'form-data',


### PR DESCRIPTION
sysread can't be used against UTF8 handles (deprecated since perl 5.24,
fatal since 5.30).  The only reasonable way to slurp an entire file
through an encoding layer is to use readline.  Using a read loop would
not be faster.

This matches what File::Slurper does internally. Compared to the patch in [RT#125843](https://rt.cpan.org/Ticket/Display.html?id=125843), this should work for any encoding.