### PR TITLE
When from_psgi_response, a bug when headers are already output and ch…

### DIFF
--- a/lib/Catalyst/Response.pm
+++ b/lib/Catalyst/Response.pm
@@ -196,7 +196,7 @@ sub from_psgi_response {
         die "You can't set a Catalyst response from that, expect a valid PSGI response";
     }
 
-    return if $self->finalized_headers;
+    return unless $self->_context->has_encoding;
 
     # Encoding compatibilty.   If the response set a charset, well... we need
     # to assume its properly encoded and NOT encode for this response.  Otherwise

--- a/lib/Catalyst/Response.pm
+++ b/lib/Catalyst/Response.pm
@@ -196,6 +196,8 @@ sub from_psgi_response {
         die "You can't set a Catalyst response from that, expect a valid PSGI response";
     }
 
+    return if $self->finalized_headers;
+
     # Encoding compatibilty.   If the response set a charset, well... we need
     # to assume its properly encoded and NOT encode for this response.  Otherwise
     # We risk double encoding.

--- a/t/psgi_utils.t
+++ b/t/psgi_utils.t
@@ -73,6 +73,7 @@ my $psgi_app = sub {
         $writer->write("body");
         $writer->close;
     };
+    $c->clear_encoding;
     $c->res->from_psgi_response($psgi_app);
   }
 

--- a/t/psgi_utils.t
+++ b/t/psgi_utils.t
@@ -55,6 +55,27 @@ my $psgi_app = sub {
     $c->res->from_psgi_response([200, ['Content-Type'=>'text/html'], ["hello","world"]]);
   }
 
+  sub streaming_body :Local {
+    my ($self, $c) = @_;
+    my $psgi_app = sub {
+        my $respond = shift;
+        my $writer = $respond->([200,["Content-Type" => "text/plain"]]);
+        $writer->write("body");
+        $writer->close;
+    };
+    $c->res->from_psgi_response($psgi_app);
+  }
+  sub streaming_body_with_charset :Local {
+    my ($self, $c) = @_;
+    my $psgi_app = sub {
+        my $respond = shift;
+        my $writer = $respond->([200,["Content-Type" => "text/plain; charset=utf-8"]]);
+        $writer->write("body");
+        $writer->close;
+    };
+    $c->res->from_psgi_response($psgi_app);
+  }
+
   package MyApp::Controller::User;
   $INC{'MyApp/Controller/User.pm'} = __FILE__;
 
@@ -405,6 +426,15 @@ use Catalyst::Test 'MyApp';
 {
   my ($res, $c) = ctx_request('/docs/direct');
   is $res->content, "helloworld";
+}
+
+{
+  my ($res, $c) = ctx_request('/docs/streaming_body');
+  is $res->content, "body";
+}
+{
+  my ($res, $c) = ctx_request('/docs/streaming_body_with_charset');
+  is $res->content, "body";
 }
 
 done_testing();


### PR DESCRIPTION
Hello.

There was a problem when using Plack::App::Proxy.
A problem seems to arise if $c->res->finalized_headers and $c->res->content_type_charset.

I do not know the good patch, but in my environment have been resolved with this.

<pre>
% prove -I lib t/psgi_utils.t                                                                                                                    
t/psgi_utils.t .. 38/? [error] Caught exception in MyApp::Controller::Docs->stream_and_charset "You may not change the encoding once the headers are finalized
 at /usr/home/bokutin/code/reading/catalyst-runtime/lib/Catalyst/Response.pm line 202."                                                                      
[warn] Useless setting a header value after finalize_headers and the response callback has been called. Since we don't support tail headers this will not work
 as you might expect.                                                                                                                                        
[warn] Useless setting a header value after finalize_headers and the response callback has been called. Since we don't support tail headers this will not work
 as you might expect.                                                                                                                                        
t/psgi_utils.t .. ok      
</pre>