### PR TITLE
Suppress warnings for Getopt::Long::Descriptive.

### DIFF
--- a/lib/Catalyst/Script/Server.pm
+++ b/lib/Catalyst/Script/Server.pm
@@ -6,6 +6,10 @@ use namespace::clean -except => [ 'meta' ];
 
 with 'Catalyst::ScriptRole';
 
+has '+help_flag' => (
+    cmd_aliases   => [qw(usage ?)],
+);
+
 has debug => (
     traits        => [qw(Getopt)],
     cmd_aliases   => 'd',


### PR DESCRIPTION
Starting with Getopt-Long-Descriptive-0.108, you will be warned.

% ./script/myapp_web_server.pl -d
Getopt::Long::Descriptive was configured with these ambiguous options: h

Conflicts with "--host" option of Catalyst::Script::Server.

https://metacpan.org/release/RJBS/Getopt-Long-Descriptive-0.108/source/lib/Getopt/Long/Descriptive.pm#L450