### PR TITLE
Forward to instances

### DIFF
--- a/lib/Catalyst.pm
+++ b/lib/Catalyst.pm
@@ -420,6 +420,9 @@ check if you are writing plugins that run before a request is finalized.
 
 =head2 $c->forward( $class, $method, [, \@arguments ] )
 
+=head2 $c->forward( $component_instance, $method, [, \@arguments ] )
+
+
 This is one way of calling another action (method) in the same or
 a different controller. You can also use C<< $self->my_method($c, @args) >>
 in the same controller or C<< $c->controller('MyController')->my_method($c, @args) >>
@@ -476,6 +479,10 @@ or stash it like so:
 and access it from the stash.
 
 Keep in mind that the C<end> method used is that of the caller action. So a C<< $c->detach >> inside a forwarded action would run the C<end> method from the original action requested.
+
+If you call c<forward> with the name of a component class or instance, rather than an action name
+or instance, we invoke the C<process> action on that class or instance, or whatever action you
+specific via the second argument $method.
 
 =cut
 

--- a/lib/Catalyst/Action.pm
+++ b/lib/Catalyst/Action.pm
@@ -26,6 +26,7 @@ with 'MooseX::Emulate::Class::Accessor::Fast';
 use namespace::clean -except => 'meta';
 
 has class => (is => 'rw');
+has instance => (is=>'ro', required=>0, predicate=>'has_instance');
 has namespace => (is => 'rw');
 has 'reverse' => (is => 'rw');
 has attributes => (is => 'rw');
@@ -361,7 +362,11 @@ no warnings 'recursion';
 
 sub dispatch {    # Execute ourselves against a context
     my ( $self, $c ) = @_;
-    return $c->execute( $self->class, $self );
+    if($self->has_instance) {
+        return $c->execute( $self->instance, $self );
+    } else {
+        return $c->execute( $self->class, $self );
+    }
 }
 
 sub execute {

--- a/lib/Catalyst/Dispatcher.pm
+++ b/lib/Catalyst/Dispatcher.pm
@@ -328,39 +328,39 @@ sub _find_component {
 }
 
 sub _invoke_as_component {
-  my ( $self, $c, $component_or_class, $method ) = @_;
+    my ( $self, $c, $component_or_class, $method ) = @_;
 
-  my $component = $self->_find_component($c, $component_or_class);
-  my $component_class = blessed $component || return 0;
+    my $component = $self->_find_component($c, $component_or_class);
+    my $component_class = blessed $component || return 0;
 
-  if (my $code = $component_class->can('action_for')) {
-      my $possible_action = $component->$code($method);
-      return $possible_action if $possible_action;
-  }
+    if (my $code = $component_class->can('action_for')) {
+        my $possible_action = $component->$code($method);
+        return $possible_action if $possible_action;
+    }
 
-  my $component_to_call = blessed($component_or_class) ? $component_or_class : $component_class;
+    my $component_to_call = blessed($component_or_class) ? $component_or_class : $component_class;
 
-  if ( my $code = $component_to_call->can($method) ) {
-      return $self->_method_action_class->new(
-          {
-              name      => $method,
-              code      => $code,
-              reverse   => "$component_class->$method",
-              class     => $component_to_call,
-              namespace => Catalyst::Utils::class2prefix(
-                  $component_class, ref($c)->config->{case_sensitive}
-              ),
-          }
-      );
-  }
-  else {
-      my $error =
-        qq/Couldn't forward to "$component_class". Does not implement "$method"/;
-      $c->error($error);
-      $c->log->debug($error)
-        if $c->debug;
-      return 0;
-  }
+    if ( my $code = $component_to_call->can($method) ) {
+        return $self->_method_action_class->new(
+            {
+                name      => $method,
+                code      => $code,
+                reverse   => "$component_class->$method",
+                class     => $component_to_call,
+                namespace => Catalyst::Utils::class2prefix(
+                    $component_class, ref($c)->config->{case_sensitive}
+                ),
+            }
+        );
+    }
+    else {
+        my $error =
+          qq/Couldn't forward to "$component_class". Does not implement "$method"/;
+        $c->error($error);
+        $c->log->debug($error)
+          if $c->debug;
+        return 0;
+    }
 }
 
 =head2 $self->prepare_action($c)

--- a/lib/Catalyst/Dispatcher.pm
+++ b/lib/Catalyst/Dispatcher.pm
@@ -150,6 +150,7 @@ sub _command2action {
 
     # go to a string path ("/foo/bar/gorch")
     # or action object
+    #
     if (blessed($command) && $command->isa('Catalyst::Action')) {
         $action = $command;
     }
@@ -338,15 +339,14 @@ sub _invoke_as_component {
         return $possible_action if $possible_action;
     }
 
-    my $component_to_call = blessed($component_or_class) ? $component_or_class : $component_class;
-
-    if ( my $code = $component_to_call->can($method) ) {
+    if ( my $code = $component_class->can($method) ) {
         return $self->_method_action_class->new(
             {
                 name      => $method,
                 code      => $code,
                 reverse   => "$component_class->$method",
-                class     => $component_to_call,
+                class     => $component_class,
+                ( blessed($component_or_class) ? (instance => $component_or_class):() ),
                 namespace => Catalyst::Utils::class2prefix(
                     $component_class, ref($c)->config->{case_sensitive}
                 ),

--- a/lib/Catalyst/Dispatcher.pm
+++ b/lib/Catalyst/Dispatcher.pm
@@ -328,37 +328,39 @@ sub _find_component {
 }
 
 sub _invoke_as_component {
-    my ( $self, $c, $component_or_class, $method ) = @_;
+  my ( $self, $c, $component_or_class, $method ) = @_;
 
-    my $component = $self->_find_component($c, $component_or_class);
-    my $component_class = blessed $component || return 0;
+  my $component = $self->_find_component($c, $component_or_class);
+  my $component_class = blessed $component || return 0;
 
-    if (my $code = $component_class->can('action_for')) {
-        my $possible_action = $component->$code($method);
-        return $possible_action if $possible_action;
-    }
+  if (my $code = $component_class->can('action_for')) {
+      my $possible_action = $component->$code($method);
+      return $possible_action if $possible_action;
+  }
 
-    if ( my $code = $component_class->can($method) ) {
-        return $self->_method_action_class->new(
-            {
-                name      => $method,
-                code      => $code,
-                reverse   => "$component_class->$method",
-                class     => $component_class,
-                namespace => Catalyst::Utils::class2prefix(
-                    $component_class, ref($c)->config->{case_sensitive}
-                ),
-            }
-        );
-    }
-    else {
-        my $error =
-          qq/Couldn't forward to "$component_class". Does not implement "$method"/;
-        $c->error($error);
-        $c->log->debug($error)
-          if $c->debug;
-        return 0;
-    }
+  my $component_to_call = blessed($component_or_class) ? $component_or_class : $component_class;
+
+  if ( my $code = $component_to_call->can($method) ) {
+      return $self->_method_action_class->new(
+          {
+              name      => $method,
+              code      => $code,
+              reverse   => "$component_class->$method",
+              class     => $component_to_call,
+              namespace => Catalyst::Utils::class2prefix(
+                  $component_class, ref($c)->config->{case_sensitive}
+              ),
+          }
+      );
+  }
+  else {
+      my $error =
+        qq/Couldn't forward to "$component_class". Does not implement "$method"/;
+      $c->error($error);
+      $c->log->debug($error)
+        if $c->debug;
+      return 0;
+  }
 }
 
 =head2 $self->prepare_action($c)

--- a/lib/Catalyst/Dispatcher.pm
+++ b/lib/Catalyst/Dispatcher.pm
@@ -150,7 +150,6 @@ sub _command2action {
 
     # go to a string path ("/foo/bar/gorch")
     # or action object
-    #
     if (blessed($command) && $command->isa('Catalyst::Action')) {
         $action = $command;
     }

--- a/t/forward_instances.t
+++ b/t/forward_instances.t
@@ -15,8 +15,12 @@ use Test::More;
     my( $self, $c ) = @_;
     my $view = $c->view('Test');
     $c->forward($view);
+  }
 
-    Test::More::is("$view", "@{[ $c->res->body]}");
+  sub test_custom :Local Args(0) {
+    my( $self, $c ) = @_;
+    my $view = $c->view('Test');
+    $c->forward($view, 'custom');
   }
 
   package MyApp::View::Test;
@@ -31,8 +35,14 @@ use Test::More;
 
   sub process {
     my ($self, $c, @args) = @_;
-    $c->res->body("$self");
+    $c->res->body(ref $self);
   }
+
+  sub custom {
+    my ($self, $c, @args) = @_;
+    $c->res->body("custom: @{[ ref $self]}");
+  }
+
 
   package MyApp;
   use Catalyst;
@@ -44,6 +54,13 @@ use Catalyst::Test 'MyApp';
 
 {
   ok my $res = request GET 'root/test_forward';
+  is $res->content, 'MyApp::View::Test';
 }
 
-done_testing(2);
+{
+  ok my $res = request GET 'root/test_custom';
+  is $res->content, 'custom: MyApp::View::Test';
+
+}
+
+done_testing(4);

--- a/t/forward_instances.t
+++ b/t/forward_instances.t
@@ -11,7 +11,7 @@ use Test::More;
 
   use base 'Catalyst::Controller';
 
-  sub test :Local Args(0) {
+  sub test_forward :Local Args(0) {
     my( $self, $c ) = @_;
     my $view = $c->view('Test');
     $c->forward($view);
@@ -32,7 +32,6 @@ use Test::More;
   sub process {
     my ($self, $c, @args) = @_;
     $c->res->body("$self");
-
   }
 
   package MyApp;
@@ -44,7 +43,7 @@ use HTTP::Request::Common;
 use Catalyst::Test 'MyApp';
 
 {
-  ok my $res = request GET 'root/test';
+  ok my $res = request GET 'root/test_forward';
 }
 
 done_testing(2);

--- a/t/forward_instances.t
+++ b/t/forward_instances.t
@@ -1,0 +1,50 @@
+use warnings;
+use strict;
+use Test::More;
+
+# Test case for reported issue when an action consumes JSON but a
+# POST sends nothing we get a hard error
+
+{
+  package MyApp::Controller::Root;
+  $INC{'MyApp/Controller/Root.pm'} = __FILE__;
+
+  use base 'Catalyst::Controller';
+
+  sub test :Local Args(0) {
+    my( $self, $c ) = @_;
+    my $view = $c->view('Test');
+    $c->forward($view);
+
+    Test::More::is("$view", "@{[ $c->res->body]}");
+  }
+
+  package MyApp::View::Test;
+  $INC{'MyApp/View/Test.pm'} = __FILE__;
+
+  use base 'Catalyst::View';
+
+  sub ACCEPT_CONTEXT {
+    my ($self, $c, @args) = @_;
+    return ref($self)->new;
+  }
+
+  sub process {
+    my ($self, $c, @args) = @_;
+    $c->res->body("$self");
+
+  }
+
+  package MyApp;
+  use Catalyst;
+  MyApp->setup;
+}
+
+use HTTP::Request::Common;
+use Catalyst::Test 'MyApp';
+
+{
+  ok my $res = request GET 'root/test';
+}
+
+done_testing(2);


### PR DESCRIPTION
Right now if you $c->forward($view) where $view is an instance
of a view the code will create a new view object of the same
type and forward to that, rather than forward to the view
instance (and other components).  This fixes that.

It's really messing up some of the work I've been doing around 'view per context'.  I think we never got bit by that because that approach isn't common.