### PR TITLE
fix exit status

### DIFF
--- a/xt/author/http-server.t
+++ b/xt/author/http-server.t
@@ -92,7 +92,7 @@ sub prove {
 
         my $aggregator = $harness->runtests(@tests);
 
-        exit $aggregator->has_errors ? 1 : 0;
+        exit($aggregator->has_errors ? 1 : 0);
     } else {
         waitpid $pid, 0;
         return $?;


### PR DESCRIPTION
`exit` has higher precedence than `?:`, so `exit $has_errors ? 1 : 0` parses as `(exit $has_errors) ? 1 : 0`, which is not what was intended.