### PR TITLE
Fix reversed logic in POD in Catalyst.pm

### DIFF
--- a/lib/Catalyst.pm
+++ b/lib/Catalyst.pm
@@ -4570,7 +4570,7 @@ headers.
 
 If you do not wish to use the proxy support at all, you may set:
 
-    MyApp->config(ignore_frontend_proxy => 0);
+    MyApp->config(ignore_frontend_proxy => 1);
 
 =head2 Note about psgi files
 


### PR DESCRIPTION
I confirmed that you can set `ignore_frontend_proxy` to a true value. See `t/aggregate/live_engine_request_headers.t`.

Really weird that this was changed to `0` in d685f38e02912b15dc8d08499e4006561d7174a2 by @bobtfish while working on PSGI support. I think this must have been an accident?