### PR TITLE
Document Catalyst behavior related to io_fh

### DIFF
--- a/lib/Catalyst.pm
+++ b/lib/Catalyst.pm
@@ -2172,7 +2172,9 @@ sub _stats_finish_execute {
 
 =head2 $c->finalize
 
-Finalizes the request.
+Finalizes the request.  This logs errors, logs the request, and then writes
+the HTTP response to the client unless C<< $c->request->io_fh >> is being used
+to respond in some other manner. (i.e. comet or websockets)
 
 =cut
 

--- a/lib/Catalyst/Engine.pm
+++ b/lib/Catalyst/Engine.pm
@@ -58,9 +58,12 @@ a filehandle, otherwise write it out all in one go.  If there is no body in
 the response, we assume you are handling it 'manually', such as for nonblocking
 style or asynchronous streaming responses.  You do this by calling L</write>
 several times (which sends HTTP headers if needed) or you close over
-C<< $response->write_fh >>.
+C<< $response->write_fh >>.  Note that this method (and the entire C<finalize>
+sequence of the Engine) is bypassed entirely if you are using
+C<< $request->io_fh >> for things like comet or websockets.
 
-See L<Catalyst::Response/write> and L<Catalyst::Response/write_fh> for more.
+See L<Catalyst::Response/write>, L<Catalyst::Response/write_fh> and
+L<Catalyst::Request/io_fh> for more.
 
 =cut
 

--- a/lib/Catalyst/Request.pm
+++ b/lib/Catalyst/Request.pm
@@ -496,6 +496,7 @@ Catalyst::Request - provides information about the current client request
     $req->headers;
     $req->hostname;
     $req->input;
+    $req->io_fh;
     $req->query_keywords;
     $req->match;
     $req->method;
@@ -1106,6 +1107,9 @@ version string.
 Returns a psgix.io bidirectional socket, if your server supports one.  Used for
 when you want to jailbreak out of PSGI and handle bidirectional client server
 communication manually, such as when you are using cometd or websockets.
+Note that I<accessing> this attribute will prevent Catalyst from writing an
+HTTP response.  Once you have the file handle, it is your responsibility to
+handle the remainder of the connection.
 
 =head1 SETUP METHODS
 


### PR DESCRIPTION
Catalyst has supported websockets for nearly 13 years, but this support was very difficult to discover from the public documentation.  These documentation changes make the behavior of the io_fh feature more explicit and easier to find.